### PR TITLE
DT-1581 publish wrong artifact name

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,7 @@ workflows:
             branches:
               only:
                 - main
-                - mh-DT-1581-multi-project-versio
+                - mh-DT-1581-publish-wrong-name
       - publish:
           requires:
             - publish-approval
@@ -82,7 +82,7 @@ workflows:
             branches:
               only:
                 - main
-                - mh-DT-1581-multi-project-versio
+                - mh-DT-1581-publish-wrong-name
 
   security:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,6 +74,7 @@ workflows:
             branches:
               only:
                 - main
+                - mh-DT-1581-multi-project-versio
       - publish:
           requires:
             - publish-approval
@@ -81,6 +82,7 @@ workflows:
             branches:
               only:
                 - main
+                - mh-DT-1581-multi-project-versio
 
   security:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,6 @@ workflows:
             branches:
               only:
                 - main
-                - mh-DT-1581-publish-wrong-name
       - publish:
           requires:
             - publish-approval
@@ -82,7 +81,6 @@ workflows:
             branches:
               only:
                 - main
-                - mh-DT-1581-publish-wrong-name
 
   security:
     triggers:

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -15,7 +15,7 @@ plugins {
 }
 
 base.archivesBaseName = "hmpps-spring-boot-sqs"
-version = "0.1.4.1"
+version = "0.1.5"
 
 dependencies {
   api("org.springframework.boot:spring-boot-starter")
@@ -36,7 +36,8 @@ publishing {
     create<MavenPublication>("maven") {
       from(components["java"])
       pom {
-        name.set("hmpps-spring-boot-sqs")
+        name.set(base.archivesBaseName)
+        artifactId = base.archivesBaseName
         description.set("A helper library providing utilities for using amazon-sqs-java-messaging-lib")
         url.set("https://github.com/ministryofjustice/hmpps-spring-boot-sqs")
         licenses {

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -15,7 +15,7 @@ plugins {
 }
 
 base.archivesBaseName = "hmpps-spring-boot-sqs"
-version = "0.1.4"
+version = "0.1.4.1"
 
 dependencies {
   api("org.springframework.boot:spring-boot-starter")


### PR DESCRIPTION
The nexus plugin seems to rename the jar to whatever `artifactId` is, so make that the same as the project.