### PR TITLE
DT-2295 bean ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ As each topic has its own access key and secret we create an Amazon SNS client f
 
 To remove this pain each topic defined in `HmppsSqsProperties` should have an `AmazonSNS` created.
 
-The bean names have the format `<queueId-sns-client` and can be used with `@Qualifier` to inject the beans into another `@Component`:
+The bean names have the format `<topicId>-sns-client` and can be used with `@Qualifier` to inject the beans into another `@Component`:
 
 #### LocalStack AmazonSNS Beans
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 
 allprojects {
   group = "uk.gov.justice.service.hmpps"
-  version = "0.7.0"
+  version = "0.7.1"
 }
 
 nexusPublishing {

--- a/lib/src/main/kotlin/uk/gov/justice/hmpps/sqs/HmppsSqsConfiguration.kt
+++ b/lib/src/main/kotlin/uk/gov/justice/hmpps/sqs/HmppsSqsConfiguration.kt
@@ -1,6 +1,8 @@
 package uk.gov.justice.hmpps.sqs
 
 import com.microsoft.applicationinsights.TelemetryClient
+import org.springframework.boot.actuate.autoconfigure.health.HealthEndpointAutoConfiguration
+import org.springframework.boot.autoconfigure.AutoConfigureBefore
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.ConfigurableApplicationContext
 import org.springframework.context.annotation.Bean
@@ -11,6 +13,7 @@ import org.springframework.jms.annotation.EnableJms
 @Configuration
 @EnableConfigurationProperties(HmppsSqsProperties::class)
 @EnableJms
+@AutoConfigureBefore(HealthEndpointAutoConfiguration::class)
 class HmppsSqsConfiguration {
 
   @Bean


### PR DESCRIPTION
As our library's auto-configuration produces HealthIndicator beans, it must run before the health auto-configuration.