### PR TITLE
DT-2414 Add tests for queues with no dlqs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 
 allprojects {
   group = "uk.gov.justice.service.hmpps"
-  version = "0.8.2"
+  version = "0.8.2-beta-2"
 }
 
 nexusPublishing {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 
 allprojects {
   group = "uk.gov.justice.service.hmpps"
-  version = "0.8.2-beta"
+  version = "0.8.2"
 }
 
 nexusPublishing {

--- a/hmpps-sqs-spring-boot-autoconfigure/src/main/kotlin/uk/gov/justice/hmpps/sqs/HmppsQueue.kt
+++ b/hmpps-sqs-spring-boot-autoconfigure/src/main/kotlin/uk/gov/justice/hmpps/sqs/HmppsQueue.kt
@@ -10,5 +10,5 @@ class HmppsQueue(
   val dlqName: String? = null
 ) {
   val queueUrl: String by lazy { sqsClient.getQueueUrl(queueName).queueUrl }
-  val dlqUrl: String? by lazy { sqsDlqClient?.getQueueUrl(dlqName)?.queueUrl }
+  val dlqUrl by lazy { sqsDlqClient?.getQueueUrl(dlqName)?.queueUrl }
 }

--- a/hmpps-sqs-spring-boot-autoconfigure/src/test/kotlin/uk/gov/justice/hmpps/sqs/HmppsNoDlqQueueFactoryTest.kt
+++ b/hmpps-sqs-spring-boot-autoconfigure/src/test/kotlin/uk/gov/justice/hmpps/sqs/HmppsNoDlqQueueFactoryTest.kt
@@ -1,0 +1,385 @@
+package uk.gov.justice.hmpps.sqs
+
+import com.amazonaws.services.sns.AmazonSNS
+import com.amazonaws.services.sqs.AmazonSQS
+import com.amazonaws.services.sqs.AmazonSQSAsync
+import com.amazonaws.services.sqs.model.CreateQueueRequest
+import com.amazonaws.services.sqs.model.GetQueueUrlResult
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.check
+import com.nhaarman.mockitokotlin2.eq
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.never
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
+import com.nhaarman.mockitokotlin2.whenever
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.ArgumentMatchers.anyBoolean
+import org.mockito.ArgumentMatchers.anyString
+import org.mockito.ArgumentMatchers.contains
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory
+import org.springframework.context.ConfigurableApplicationContext
+import uk.gov.justice.hmpps.sqs.HmppsSqsProperties.QueueConfig
+import uk.gov.justice.hmpps.sqs.HmppsSqsProperties.TopicConfig
+
+class HmppsNoDlqQueueFactoryTest {
+
+  private val localstackArnPrefix = "arn:aws:sns:eu-west-2:000000000000:"
+
+  private val context = mock<ConfigurableApplicationContext>()
+  private val beanFactory = mock<ConfigurableListableBeanFactory>()
+  private val sqsFactory = mock<AmazonSqsFactory>()
+  private val hmppsQueueFactory = HmppsQueueFactory(context, sqsFactory)
+
+  init {
+    whenever(context.beanFactory).thenReturn(beanFactory)
+  }
+
+  @Nested
+  inner class `Create single AWS HmppsQueue with no dlq` {
+    private val someQueueConfig = QueueConfig(queueName = "some queue name", queueAccessKeyId = "some access key id", queueSecretAccessKey = "some secret access key")
+    private val hmppsSqsProperties = HmppsSqsProperties(queues = mapOf("somequeueid" to someQueueConfig))
+    private val sqsClient = mock<AmazonSQS>()
+    private lateinit var hmppsQueues: List<HmppsQueue>
+
+    @BeforeEach
+    fun `configure mocks and register queues`() {
+      whenever(sqsFactory.awsSqsClient(anyString(), anyString(), anyString(), anyString(), anyString(), anyBoolean()))
+        .thenReturn(sqsClient)
+      whenever(sqsClient.getQueueUrl(anyString())).thenReturn(GetQueueUrlResult().withQueueUrl("some queue url"))
+
+      hmppsQueues = hmppsQueueFactory.createHmppsQueues(hmppsSqsProperties)
+    }
+
+    @Test
+    fun `creates aws sqs client but does not create aws sqs dlq client from sqs factory`() {
+      verify(sqsFactory).awsSqsClient("somequeueid", "some queue name", "some access key id", "some secret access key", "eu-west-2", false)
+      verifyNoMoreInteractions(sqsFactory)
+    }
+
+    @Test
+    fun `should return the queue details`() {
+      assertThat(hmppsQueues[0].id).isEqualTo("somequeueid")
+    }
+
+    @Test
+    fun `should return the queue AmazonSQS client`() {
+      assertThat(hmppsQueues[0].sqsClient).isEqualTo(sqsClient)
+    }
+
+    @Test
+    fun `should return the queue name`() {
+      assertThat(hmppsQueues[0].queueName).isEqualTo("some queue name")
+    }
+
+    @Test
+    fun `should return the queue url`() {
+      assertThat(hmppsQueues[0].queueUrl).isEqualTo("some queue url")
+    }
+
+    @Test
+    fun `should not return dlq client`() {
+      assertThat(hmppsQueues[0].sqsDlqClient).isNull()
+    }
+
+    @Test
+    fun `should not return dlq name`() {
+      assertThat(hmppsQueues[0].dlqName).isNull()
+    }
+
+    @Test
+    fun `should not return dlq url`() {
+      assertThat(hmppsQueues[0].dlqUrl).isNull()
+    }
+
+    @Test
+    fun `should register a health indicator`() {
+      verify(beanFactory).registerSingleton(eq("somequeueid-health"), any<HmppsQueueHealth>())
+    }
+
+    @Test
+    fun `should register the sqs client but not the dlq client`() {
+      verify(beanFactory).registerSingleton("somequeueid-sqs-client", sqsClient)
+      verify(beanFactory, never()).registerSingleton(contains("dlq-client"), any<AmazonSQS>())
+    }
+
+    @Test
+    fun `should register the jms listener factory`() {
+      verify(beanFactory).registerSingleton(eq("somequeueid-jms-listener-factory"), any<HmppsQueueDestinationContainerFactory>())
+    }
+  }
+
+  @Nested
+  inner class `Create single LocalStack HmppsQueue with no dlq` {
+    private val someQueueConfig = QueueConfig(queueName = "some queue name")
+    private val hmppsSqsProperties = HmppsSqsProperties(provider = "localstack", queues = mapOf("somequeueid" to someQueueConfig))
+    private val sqsClient = mock<AmazonSQS>()
+    private lateinit var hmppsQueues: List<HmppsQueue>
+
+    @BeforeEach
+    fun `configure mocks and register queues`() {
+      whenever(sqsFactory.localStackSqsClient(anyString(), anyString(), anyString(), anyString(), anyBoolean()))
+        .thenReturn(sqsClient)
+      whenever(sqsClient.getQueueUrl(anyString())).thenReturn(GetQueueUrlResult().withQueueUrl("some queue url"))
+
+      hmppsQueues = hmppsQueueFactory.createHmppsQueues(hmppsSqsProperties)
+    }
+
+    @Test
+    fun `creates LocalStack sqs client from sqs factory but not dlq client`() {
+      verify(sqsFactory).localStackSqsClient(queueId = "somequeueid", localstackUrl = "http://localhost:4566", region = "eu-west-2", queueName = "some queue name", asyncClient = false)
+      verifyNoMoreInteractions(sqsFactory)
+    }
+
+    @Test
+    fun `should return the queue details`() {
+      assertThat(hmppsQueues[0].id).isEqualTo("somequeueid")
+    }
+
+    @Test
+    fun `should return the queue AmazonSQS client`() {
+      assertThat(hmppsQueues[0].sqsClient).isEqualTo(sqsClient)
+    }
+
+    @Test
+    fun `should return the queue name`() {
+      assertThat(hmppsQueues[0].queueName).isEqualTo("some queue name")
+    }
+
+    @Test
+    fun `should return the queue url`() {
+      assertThat(hmppsQueues[0].queueUrl).isEqualTo("some queue url")
+    }
+
+    @Test
+    fun `should not return a dlq client`() {
+      assertThat(hmppsQueues[0].sqsDlqClient).isNull()
+    }
+
+    @Test
+    fun `should not return a dlq name`() {
+      assertThat(hmppsQueues[0].dlqName).isNull()
+    }
+
+    @Test
+    fun `should not return a dlq url`() {
+      assertThat(hmppsQueues[0].dlqUrl).isNull()
+    }
+
+    @Test
+    fun `should register a health indicator`() {
+      verify(beanFactory).registerSingleton(eq("somequeueid-health"), any<HmppsQueueHealth>())
+    }
+
+    @Test
+    fun `should register the sqs client but not the dlq client`() {
+      verify(beanFactory).registerSingleton("somequeueid-sqs-client", sqsClient)
+      verify(beanFactory, never()).registerSingleton(contains("dlq-client"), any<AmazonSQS>())
+    }
+
+    @Test
+    fun `should create a queue without a redrive policy`() {
+      verify(sqsClient).createQueue(
+        check<CreateQueueRequest> {
+          assertThat(it.attributes).doesNotContainEntry("RedrivePolicy", """{"deadLetterTargetArn":"some dlq arn","maxReceiveCount":"5"}""")
+        }
+      )
+    }
+  }
+
+  @Nested
+  inner class `Create multiple AWS HmppsQueues without dlqs` {
+    private val someQueueConfig = QueueConfig(queueName = "some queue name", queueAccessKeyId = "some access key id", queueSecretAccessKey = "some secret access key")
+    private val anotherQueueConfig = QueueConfig(queueName = "another queue name", queueAccessKeyId = "another access key id", queueSecretAccessKey = "another secret access key")
+    private val hmppsSqsProperties = HmppsSqsProperties(queues = mapOf("somequeueid" to someQueueConfig, "anotherqueueid" to anotherQueueConfig))
+    private val sqsClient = mock<AmazonSQS>()
+    private lateinit var hmppsQueues: List<HmppsQueue>
+
+    @BeforeEach
+    fun `configure mocks and register queues`() {
+      whenever(sqsFactory.awsSqsClient(anyString(), anyString(), anyString(), anyString(), anyString(), anyBoolean()))
+        .thenReturn(sqsClient)
+      whenever(sqsClient.getQueueUrl("some queue name")).thenReturn(GetQueueUrlResult().withQueueUrl("some queue url"))
+      whenever(sqsClient.getQueueUrl("another queue name")).thenReturn(GetQueueUrlResult().withQueueUrl("another queue url"))
+
+      hmppsQueues = hmppsQueueFactory.createHmppsQueues(hmppsSqsProperties)
+    }
+
+    @Test
+    fun `should create multiple sqs clients but no dlq clients from sqs factory`() {
+      verify(sqsFactory).awsSqsClient("somequeueid", "some queue name", "some access key id", "some secret access key", "eu-west-2", false)
+      verify(sqsFactory).awsSqsClient("anotherqueueid", "another queue name", "another access key id", "another secret access key", "eu-west-2", false)
+      verifyNoMoreInteractions(sqsFactory)
+    }
+
+    @Test
+    fun `should return multiple queue details`() {
+      assertThat(hmppsQueues[0].id).isEqualTo("somequeueid")
+      assertThat(hmppsQueues[1].id).isEqualTo("anotherqueueid")
+    }
+
+    @Test
+    fun `should register multiple health indicators`() {
+      verify(beanFactory).registerSingleton(eq("somequeueid-health"), any<HmppsQueueHealth>())
+      verify(beanFactory).registerSingleton(eq("anotherqueueid-health"), any<HmppsQueueHealth>())
+    }
+  }
+
+  @Nested
+  inner class `Create AWS HmppsQueue with asynchronous SQS client` {
+    private val someQueueConfig = QueueConfig(asyncQueueClient = true, asyncDlqClient = true, queueName = "some queue name", queueAccessKeyId = "some access key id", queueSecretAccessKey = "some secret access key")
+    private val hmppsSqsProperties = HmppsSqsProperties(queues = mapOf("somequeueid" to someQueueConfig))
+    private val sqsClient = mock<AmazonSQSAsync>()
+    private lateinit var hmppsQueues: List<HmppsQueue>
+
+    @BeforeEach
+    fun `configure mocks and register queues`() {
+      whenever(sqsFactory.awsSqsClient(anyString(), anyString(), anyString(), anyString(), anyString(), anyBoolean()))
+        .thenReturn(sqsClient)
+      whenever(sqsClient.getQueueUrl("some queue name")).thenReturn(GetQueueUrlResult().withQueueUrl("some queue url"))
+
+      hmppsQueues = hmppsQueueFactory.createHmppsQueues(hmppsSqsProperties)
+    }
+
+    @Test
+    fun `should create async client but no dlq client from sqs factory`() {
+      verify(sqsFactory).awsSqsClient("somequeueid", "some queue name", "some access key id", "some secret access key", "eu-west-2", true)
+      verifyNoMoreInteractions(sqsFactory)
+    }
+
+    @Test
+    fun `should return async client but no dlq client`() {
+      assertThat(hmppsQueues[0].sqsClient).isInstanceOf(AmazonSQSAsync::class.java)
+      assertThat(hmppsQueues[0].sqsDlqClient).isNull()
+    }
+
+    @Test
+    fun `should return queue details but no dlq details`() {
+      assertThat(hmppsQueues[0].id).isEqualTo("somequeueid")
+      assertThat(hmppsQueues[0].queueName).isEqualTo("some queue name")
+      assertThat(hmppsQueues[0].dlqName).isNull()
+    }
+
+    @Test
+    fun `should register a health indicator but not for dlq`() {
+      verify(beanFactory).registerSingleton(eq("somequeueid-health"), any<HmppsQueueHealth>())
+      verify(beanFactory).registerSingleton(eq("somequeueid-sqs-client"), any<AmazonSQS>())
+      verify(beanFactory).registerSingleton(eq("somequeueid-jms-listener-factory"), any<HmppsQueueDestinationContainerFactory>())
+      verify(beanFactory, never()).registerSingleton(contains("dlq-client"), any<AmazonSQS>())
+    }
+  }
+
+  @Nested
+  inner class `Create LocalStack HmppsQueue with asynchronous SQS clients` {
+    private val someQueueConfig = QueueConfig(asyncQueueClient = true, asyncDlqClient = true, queueName = "some queue name")
+    private val hmppsSqsProperties = HmppsSqsProperties(provider = "localstack", queues = mapOf("somequeueid" to someQueueConfig))
+    private val sqsClient = mock<AmazonSQSAsync>()
+    private lateinit var hmppsQueues: List<HmppsQueue>
+
+    @BeforeEach
+    fun `configure mocks and register queues`() {
+      whenever(sqsFactory.localStackSqsClient(anyString(), anyString(), anyString(), anyString(), anyBoolean()))
+        .thenReturn(sqsClient)
+      whenever(sqsClient.getQueueUrl("some queue name")).thenReturn(GetQueueUrlResult().withQueueUrl("some queue url"))
+
+      hmppsQueues = hmppsQueueFactory.createHmppsQueues(hmppsSqsProperties)
+    }
+
+    @Test
+    fun `should create async client but no dlq from sqs factory`() {
+      verify(sqsFactory).localStackSqsClient("somequeueid", "some queue name", "http://localhost:4566", "eu-west-2", true)
+      verify(sqsFactory, never()).localStackSqsDlqClient(anyString(), anyString(), anyString(), anyString(), anyBoolean())
+    }
+
+    @Test
+    fun `should return async client but no dlq client`() {
+      assertThat(hmppsQueues[0].sqsClient).isInstanceOf(AmazonSQSAsync::class.java)
+      assertThat(hmppsQueues[0].sqsDlqClient).isNull()
+    }
+
+    @Test
+    fun `should return queue details but no dlq details`() {
+      assertThat(hmppsQueues[0].id).isEqualTo("somequeueid")
+      assertThat(hmppsQueues[0].queueName).isEqualTo("some queue name")
+      assertThat(hmppsQueues[0].dlqName).isNull()
+    }
+
+    @Test
+    fun `should register all beans created`() {
+      verify(beanFactory).registerSingleton(eq("somequeueid-health"), any<HmppsQueueHealth>())
+      verify(beanFactory).registerSingleton(eq("somequeueid-sqs-client"), any<AmazonSQS>())
+      verify(beanFactory).registerSingleton(eq("somequeueid-jms-listener-factory"), any<HmppsQueueDestinationContainerFactory>())
+      verify(beanFactory, never()).registerSingleton(contains("sqs-dlq-client"), any<AmazonSQS>())
+    }
+  }
+
+  @Nested
+  inner class `Create LocalStack HmppsQueue with topic subscription` {
+    private val someQueueConfig = QueueConfig(subscribeTopicId = "sometopicid", subscribeFilter = "some topic filter", queueName = "some-queue-name", queueAccessKeyId = "some access key id", queueSecretAccessKey = "some secret access key")
+    private val someTopicConfig = TopicConfig(arn = "${localstackArnPrefix}some-topic-name", accessKeyId = "topic access key", secretAccessKey = "topic secret")
+    private val hmppsSqsProperties = HmppsSqsProperties(provider = "localstack", queues = mapOf("somequeueid" to someQueueConfig), topics = mapOf("sometopicid" to someTopicConfig))
+    private val sqsClient = mock<AmazonSQS>()
+    private val snsClient = mock<AmazonSNS>()
+    private val topics = listOf(HmppsTopic(id = "sometopicid", arn = "some topic arn", snsClient = snsClient))
+    private lateinit var hmppsQueues: List<HmppsQueue>
+
+    @BeforeEach
+    fun `configure mocks and register queues`() {
+      whenever(sqsFactory.localStackSqsClient(anyString(), anyString(), anyString(), anyString(), anyBoolean()))
+        .thenReturn(sqsClient)
+      whenever(sqsClient.getQueueUrl(anyString())).thenReturn(GetQueueUrlResult().withQueueUrl("some queue url"))
+
+      hmppsQueues = hmppsQueueFactory.createHmppsQueues(hmppsSqsProperties, topics)
+    }
+
+    @Test
+    fun `should return the queue AmazonSQS client`() {
+      assertThat(hmppsQueues[0].sqsClient).isEqualTo(sqsClient)
+    }
+
+    @Test
+    fun `should subscribe to the topic`() {
+      verify(snsClient).subscribe(
+        check { subscribeRequest ->
+          assertThat(subscribeRequest.topicArn).isEqualTo("some topic arn")
+          assertThat(subscribeRequest.protocol).isEqualTo("sqs")
+          assertThat(subscribeRequest.endpoint).isEqualTo("http://localhost:4566/queue/some-queue-name")
+          assertThat(subscribeRequest.attributes["FilterPolicy"]).isEqualTo("some topic filter")
+        }
+      )
+    }
+  }
+
+  @Nested
+  inner class `Create AWS HmppsQueue with topic subscription` {
+    private val someQueueConfig = QueueConfig(subscribeTopicId = "sometopicid", subscribeFilter = "some topic filter", queueName = "some queue name", queueAccessKeyId = "some access key id", queueSecretAccessKey = "some secret access key")
+    private val someTopicConfig = TopicConfig(arn = "some topic arn", accessKeyId = "topic access key", secretAccessKey = "topic secret")
+    private val hmppsSqsProperties = HmppsSqsProperties(queues = mapOf("somequeueid" to someQueueConfig), topics = mapOf("sometopicid" to someTopicConfig))
+    private val sqsClient = mock<AmazonSQS>()
+    private val snsClient = mock<AmazonSNS>()
+    private val topics = listOf(HmppsTopic(id = "sometopicid", arn = "some topic arn", snsClient = snsClient))
+    private lateinit var hmppsQueues: List<HmppsQueue>
+
+    @BeforeEach
+    fun `configure mocks and register queues`() {
+      whenever(sqsFactory.awsSqsClient(anyString(), anyString(), anyString(), anyString(), anyString(), anyBoolean()))
+        .thenReturn(sqsClient)
+      whenever(sqsClient.getQueueUrl(anyString())).thenReturn(GetQueueUrlResult().withQueueUrl("some queue url"))
+
+      hmppsQueues = hmppsQueueFactory.createHmppsQueues(hmppsSqsProperties, topics)
+    }
+
+    @Test
+    fun `should return the queue AmazonSQS client`() {
+      assertThat(hmppsQueues[0].sqsClient).isEqualTo(sqsClient)
+    }
+
+    @Test
+    fun `should not subscribe to the topic`() {
+      verifyNoMoreInteractions(snsClient)
+    }
+  }
+}

--- a/hmpps-sqs-spring-boot-autoconfigure/src/test/kotlin/uk/gov/justice/hmpps/sqs/HmppsNoDlqQueueHealthTest.kt
+++ b/hmpps-sqs-spring-boot-autoconfigure/src/test/kotlin/uk/gov/justice/hmpps/sqs/HmppsNoDlqQueueHealthTest.kt
@@ -1,0 +1,150 @@
+package uk.gov.justice.hmpps.sqs
+
+import com.amazonaws.services.sqs.AmazonSQS
+import com.amazonaws.services.sqs.model.GetQueueAttributesRequest
+import com.amazonaws.services.sqs.model.GetQueueAttributesResult
+import com.amazonaws.services.sqs.model.GetQueueUrlResult
+import com.amazonaws.services.sqs.model.QueueAttributeName
+import com.amazonaws.services.sqs.model.QueueDoesNotExistException
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.ArgumentMatchers.anyString
+import org.springframework.boot.actuate.health.Status
+
+class HmppsNoDlqQueueHealthTest {
+
+  private val sqsClient = mock<AmazonSQS>()
+  private val queueId = "some queue id"
+  private val queueUrl = "some queue url"
+  private val queueName = "some queue"
+  private val messagesOnQueueCount = 123
+  private val messagesInFlightCount = 456
+  private val queueHealth = HmppsQueueHealth(HmppsQueue(queueId, sqsClient, queueName))
+
+  @Test
+  fun `should show status UP`() {
+    mockHealthyQueue()
+
+    val health = queueHealth.health()
+
+    assertThat(health.status).isEqualTo(Status.UP)
+  }
+
+  @Test
+  fun `should include queue name`() {
+    mockHealthyQueue()
+
+    val health = queueHealth.health()
+
+    assertThat(health.details["queueName"]).isEqualTo(queueName)
+  }
+
+  @Test
+  fun `should include interesting attributes`() {
+    mockHealthyQueue()
+
+    val health = queueHealth.health()
+
+    assertThat(health.details["messagesOnQueue"]).isEqualTo("$messagesOnQueueCount")
+    assertThat(health.details["messagesInFlight"]).isEqualTo("$messagesInFlightCount")
+  }
+
+  @Test
+  fun `should show status DOWN`() {
+    whenever(sqsClient.getQueueUrl(anyString())).thenThrow(QueueDoesNotExistException::class.java)
+
+    val health = queueHealth.health()
+
+    assertThat(health.status).isEqualTo(Status.DOWN)
+  }
+
+  @Test
+  fun `should show exception causing status DOWN`() {
+    whenever(sqsClient.getQueueUrl(anyString())).thenThrow(QueueDoesNotExistException::class.java)
+
+    val health = queueHealth.health()
+
+    assertThat(health.details["error"] as String).contains("Exception")
+  }
+
+  @Test
+  fun `should show queue name if status DOWN`() {
+    whenever(sqsClient.getQueueUrl(anyString())).thenThrow(QueueDoesNotExistException::class.java)
+
+    val health = queueHealth.health()
+
+    assertThat(health.details["queueName"]).isEqualTo(queueName)
+  }
+
+  @Test
+  fun `should show status DOWN if unable to retrieve queue attributes`() {
+    whenever(sqsClient.getQueueUrl(anyString())).thenReturn(someGetQueueUrlResult())
+    whenever(sqsClient.getQueueAttributes(someGetQueueAttributesRequest())).thenThrow(RuntimeException::class.java)
+
+    val health = queueHealth.health()
+
+    assertThat(health.status).isEqualTo(Status.DOWN)
+  }
+
+  @Test
+  fun `should not show DLQ name`() {
+    mockHealthyQueue()
+
+    val health = queueHealth.health()
+
+    assertThat(health.details["dlqName"]).isNull()
+  }
+
+  @Test
+  fun `should not show interesting DLQ attributes`() {
+    mockHealthyQueue()
+
+    val health = queueHealth.health()
+
+    assertThat(health.details["messagesOnDlq"]).isNull()
+  }
+
+  @Test
+  fun `should not show DLQ name if no dlq exists`() {
+    whenever(sqsClient.getQueueUrl(queueName)).thenReturn(someGetQueueUrlResult())
+    whenever(sqsClient.getQueueAttributes(someGetQueueAttributesRequest())).thenReturn(
+      someGetQueueAttributesResultWithoutDLQ()
+    )
+
+    val health = queueHealth.health()
+
+    assertThat(health.details["dlqName"]).isNull()
+  }
+
+  @Test
+  fun `should not show DLQ status if no dlq exists`() {
+    whenever(sqsClient.getQueueUrl(queueName)).thenReturn(someGetQueueUrlResult())
+    whenever(sqsClient.getQueueAttributes(someGetQueueAttributesRequest())).thenReturn(
+      someGetQueueAttributesResultWithoutDLQ()
+    )
+
+    val health = queueHealth.health()
+
+    assertThat(health.details["dlqStatus"]).isNull()
+  }
+
+  private fun mockHealthyQueue() {
+    whenever(sqsClient.getQueueUrl(queueName)).thenReturn(someGetQueueUrlResult())
+    whenever(sqsClient.getQueueAttributes(someGetQueueAttributesRequest())).thenReturn(
+      someGetQueueAttributesResultWithoutDLQ()
+    )
+  }
+
+  private fun someGetQueueAttributesRequest() =
+    GetQueueAttributesRequest(queueUrl).withAttributeNames(listOf(QueueAttributeName.All.toString()))
+
+  private fun someGetQueueUrlResult(): GetQueueUrlResult = GetQueueUrlResult().withQueueUrl(queueUrl)
+  private fun someGetQueueAttributesResultWithoutDLQ() = GetQueueAttributesResult().withAttributes(
+    mapOf(
+      "ApproximateNumberOfMessages" to "$messagesOnQueueCount",
+      "ApproximateNumberOfMessagesNotVisible" to "$messagesInFlightCount"
+    )
+  )
+}

--- a/hmpps-sqs-spring-boot-autoconfigure/src/test/kotlin/uk/gov/justice/hmpps/sqs/HmppsSqsPropertiesTest.kt
+++ b/hmpps-sqs-spring-boot-autoconfigure/src/test/kotlin/uk/gov/justice/hmpps/sqs/HmppsSqsPropertiesTest.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.hmpps.sqs
 
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatNoException
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -77,6 +78,13 @@ class HmppsSqsPropertiesTest {
     }
 
     @Test
+    fun `should not require a dlq access key ID if no dlq exists`() {
+      assertThatNoException().isThrownBy {
+        HmppsSqsProperties(queues = mapOf("queueid" to validAwsQueueNoDlqConfig().copy(dlqAccessKeyId = "")))
+      }
+    }
+
+    @Test
     fun `should require a dlq secret access key`() {
       assertThatThrownBy {
         HmppsSqsProperties(queues = mapOf("queueid" to validAwsQueueConfig().copy(dlqSecretAccessKey = "")))
@@ -86,7 +94,14 @@ class HmppsSqsPropertiesTest {
     }
 
     @Test
-    fun ` topics should have an arn`() {
+    fun `should not require a dlq secret access key if no dlq exists`() {
+      assertThatNoException().isThrownBy {
+        HmppsSqsProperties(queues = mapOf("queueid" to validAwsQueueNoDlqConfig().copy(dlqSecretAccessKey = "")))
+      }
+    }
+
+    @Test
+    fun `topics should have an arn`() {
       assertThatThrownBy {
         HmppsSqsProperties(
           queues = mapOf("queueid" to validAwsQueueConfig()),
@@ -349,6 +364,21 @@ class HmppsSqsPropertiesTest {
     }
 
     @Test
+    fun `dlq is optional`() {
+      assertThatNoException().isThrownBy {
+        HmppsSqsProperties(
+          provider = "localstack",
+          queues = mapOf(
+            "queueid1" to validLocalstackQueueNoDlqConfig(1),
+            "queueid2" to validLocalstackQueueNoDlqConfig(2),
+            "queueid3" to validLocalstackQueueNoDlqConfig(3)
+          ),
+          topics = mapOf()
+        )
+      }
+    }
+
+    @Test
     fun `topic names should be unique`() {
       assertThatThrownBy {
         HmppsSqsProperties(
@@ -390,7 +420,9 @@ class HmppsSqsPropertiesTest {
   }
 
   private fun validAwsQueueConfig(index: Int = 1) = QueueConfig(queueName = "name$index", queueAccessKeyId = "key$index", queueSecretAccessKey = "secret$index", dlqName = "dlqName$index", dlqAccessKeyId = "dlqKey$index", dlqSecretAccessKey = "dlqSecret$index")
+  private fun validAwsQueueNoDlqConfig(index: Int = 1) = QueueConfig(queueName = "name$index", queueAccessKeyId = "key$index", queueSecretAccessKey = "secret$index")
   private fun validAwsTopicConfig(index: Int = 1) = TopicConfig(arn = "arn$index", accessKeyId = "key$index", secretAccessKey = "secret$index")
   private fun validLocalstackQueueConfig(index: Int = 1) = QueueConfig(queueName = "name$index", dlqName = "dlqName$index")
+  private fun validLocalstackQueueNoDlqConfig(index: Int = 1) = QueueConfig(queueName = "name$index")
   private fun validLocalstackTopicConfig(index: Int = 1) = TopicConfig(arn = "${localstackArnPrefix}$index")
 }


### PR DESCRIPTION
These tests are mainly duplicates of tests in other files (files with NoDlq in their name), but with dlqs removed from the queues.  Even though it feels like duplication, I think it's important to ensure the non-dlq queues work in exactly the same way as those queues with dlqs