### PR TITLE
DT-2356 Change the testcontainers example to use a singleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Examples of property usage can be found in the test project in the following pla
 
 | Property | Default | Description |
 | -------- | ------- | ----------- |
-| provider | `aws` | `aws` for production or `localstack for` running locally / integration tests. (Testcontainers is not yet supported. Possibly coming soon). |
+| provider | `aws` | `aws` for production or `localstack` for running locally / integration tests.
 | region   | `eu-west-2` | The AWS region where the queues live. |
 | localstackUrl | `http://localhost:4566` | Only used for `provider=localstack`. The location of the running LocalStack instance. |
 | queues   | | A map of `queueId` to `QueueConfig`. One entry is required for each queue. In production these are derived from environment variables with the prefix `HMPPS_SQS_QUEUES_` that should be populated from Kubernetes secrets (see below).

--- a/test-app/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppstemplatepackagename/integration/testcontainers/LocalStackContainer.kt
+++ b/test-app/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppstemplatepackagename/integration/testcontainers/LocalStackContainer.kt
@@ -1,0 +1,48 @@
+package uk.gov.justice.digital.hmpps.hmppstemplatepackagename.integration.testcontainers
+
+import org.slf4j.LoggerFactory
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.testcontainers.containers.localstack.LocalStackContainer
+import org.testcontainers.containers.output.Slf4jLogConsumer
+import org.testcontainers.containers.wait.strategy.Wait
+import org.testcontainers.utility.DockerImageName
+import java.io.IOException
+import java.net.ServerSocket
+
+object LocalStackContainer {
+  val log = LoggerFactory.getLogger(this::class.java)
+  val instance by lazy { startLocalstackIfNotRunning() }
+
+  fun setLocalStackProperties(localStackContainer: LocalStackContainer, registry: DynamicPropertyRegistry) =
+    localStackContainer.getEndpointConfiguration(LocalStackContainer.Service.SNS)
+      .let { it.serviceEndpoint to it.signingRegion }
+      .also {
+        registry.add("hmpps.sqs.localstackUrl") { it.first }
+        registry.add("hmpps.sqs.region") { it.second }
+      }
+
+  private fun startLocalstackIfNotRunning(): LocalStackContainer? {
+    if (localstackIsRunning()) return null
+    val logConsumer = Slf4jLogConsumer(log).withPrefix("localstack")
+    return LocalStackContainer(
+      DockerImageName.parse("localstack/localstack").withTag("0.12.10")
+    ).apply {
+      withServices(LocalStackContainer.Service.SNS, LocalStackContainer.Service.SQS)
+      withEnv("HOSTNAME_EXTERNAL", "localhost")
+      withEnv("DEFAULT_REGION", "eu-west-2")
+      waitingFor(
+        Wait.forLogMessage(".*Ready.*", 1)
+      )
+      start()
+      followOutput(logConsumer)
+    }
+  }
+
+  private fun localstackIsRunning(): Boolean =
+    try {
+      val serverSocket = ServerSocket(4566)
+      serverSocket.localPort == 0
+    } catch (e: IOException) {
+      true
+    }
+}


### PR DESCRIPTION
This allows for the same container to be reused if Spring decides to start a new context - the current model start one for each