### PR TITLE
Example of adding an asynchronous version of the queue admin endpoints

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 
 allprojects {
   group = "uk.gov.justice.service.hmpps"
-  version = "1.1.6"
+  version = "1.1.7-beta"
 }
 
 nexusPublishing {

--- a/hmpps-sqs-spring-boot-autoconfigure/build.gradle.kts
+++ b/hmpps-sqs-spring-boot-autoconfigure/build.gradle.kts
@@ -19,6 +19,7 @@ dependencies {
   implementation("com.amazonaws:amazon-sqs-java-messaging-lib:1.1.0")
   implementation("com.amazonaws:aws-java-sdk-sns:1.12.252")
   implementation("org.springframework.boot:spring-boot-starter-web")
+  implementation("org.springframework.boot:spring-boot-starter-webflux")
   implementation("org.springframework.boot:spring-boot-starter-security")
   implementation("org.springframework.boot:spring-boot-starter-actuator")
   implementation("com.google.code.gson:gson:2.9.0")

--- a/hmpps-sqs-spring-boot-autoconfigure/src/main/kotlin/uk/gov/justice/hmpps/sqs/HmppsQueueResourceAsync.kt
+++ b/hmpps-sqs-spring-boot-autoconfigure/src/main/kotlin/uk/gov/justice/hmpps/sqs/HmppsQueueResourceAsync.kt
@@ -1,0 +1,34 @@
+package uk.gov.justice.hmpps.sqs
+
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+
+/*
+ * An asynchronous wrapper around HmppsQueueResource
+ */
+@RestController
+@RequestMapping("/queue-admin-async")
+class HmppsQueueResourceAsync(private val hmppsQueueResource: HmppsQueueResource) {
+
+  @PutMapping("/retry-dlq/{dlqName}")
+  @PreAuthorize("hasRole(@environment.getProperty('hmpps.sqs.queueAdminRole', 'ROLE_QUEUE_ADMIN'))")
+  suspend fun retryDlq(@PathVariable("dlqName") dlqName: String) = hmppsQueueResource.retryDlq(dlqName).let { Mono.just(it) }
+
+  @PutMapping("/retry-all-dlqs")
+  suspend fun retryAllDlqs() = hmppsQueueResource.retryAllDlqs().let { Flux.fromIterable(it) }
+
+  @PutMapping("/purge-queue/{queueName}")
+  @PreAuthorize("hasRole(@environment.getProperty('hmpps.sqs.queueAdminRole', 'ROLE_QUEUE_ADMIN'))")
+  suspend fun purgeQueue(@PathVariable("queueName") queueName: String) = hmppsQueueResource.purgeQueue(queueName).let { Mono.just(it) }
+
+  @GetMapping("/get-dlq-messages/{dlqName}")
+  @PreAuthorize("hasRole(@environment.getProperty('hmpps.sqs.queueAdminRole', 'ROLE_QUEUE_ADMIN'))")
+  suspend fun getDlqMessages(@PathVariable("dlqName") dlqName: String, @RequestParam("maxMessages", required = false, defaultValue = "100") maxMessages: Int) = hmppsQueueResource.getDlqMessages(dlqName, maxMessages).let { Mono.just(it) }
+}

--- a/hmpps-sqs-spring-boot-autoconfigure/src/main/kotlin/uk/gov/justice/hmpps/sqs/HmppsQueueResourceAsync.kt
+++ b/hmpps-sqs-spring-boot-autoconfigure/src/main/kotlin/uk/gov/justice/hmpps/sqs/HmppsQueueResourceAsync.kt
@@ -19,16 +19,16 @@ class HmppsQueueResourceAsync(private val hmppsQueueResource: HmppsQueueResource
 
   @PutMapping("/retry-dlq/{dlqName}")
   @PreAuthorize("hasRole(@environment.getProperty('hmpps.sqs.queueAdminRole', 'ROLE_QUEUE_ADMIN'))")
-  suspend fun retryDlq(@PathVariable("dlqName") dlqName: String): Mono<RetryDlqResult> = hmppsQueueResource.retryDlq(dlqName).let { Mono.just(it) }
+  suspend fun retryDlq(@PathVariable("dlqName") dlqName: String): Mono<RetryDlqResult> = Mono.defer { hmppsQueueResource.retryDlq(dlqName).let { Mono.just(it) } }
 
   @PutMapping("/retry-all-dlqs")
-  suspend fun retryAllDlqs(): Flux<RetryDlqResult> = hmppsQueueResource.retryAllDlqs().let { Flux.fromIterable(it) }
+  suspend fun retryAllDlqs(): Flux<RetryDlqResult> = Flux.defer { hmppsQueueResource.retryAllDlqs().let { Flux.fromIterable(it) } }
 
   @PutMapping("/purge-queue/{queueName}")
   @PreAuthorize("hasRole(@environment.getProperty('hmpps.sqs.queueAdminRole', 'ROLE_QUEUE_ADMIN'))")
-  suspend fun purgeQueue(@PathVariable("queueName") queueName: String): Mono<PurgeQueueResult> = hmppsQueueResource.purgeQueue(queueName).let { Mono.just(it) }
+  suspend fun purgeQueue(@PathVariable("queueName") queueName: String): Mono<PurgeQueueResult> = Mono.defer { hmppsQueueResource.purgeQueue(queueName).let { Mono.just(it) } }
 
   @GetMapping("/get-dlq-messages/{dlqName}")
   @PreAuthorize("hasRole(@environment.getProperty('hmpps.sqs.queueAdminRole', 'ROLE_QUEUE_ADMIN'))")
-  suspend fun getDlqMessages(@PathVariable("dlqName") dlqName: String, @RequestParam("maxMessages", required = false, defaultValue = "100") maxMessages: Int): Mono<GetDlqResult> = hmppsQueueResource.getDlqMessages(dlqName, maxMessages).let { Mono.just(it) }
+  suspend fun getDlqMessages(@PathVariable("dlqName") dlqName: String, @RequestParam("maxMessages", required = false, defaultValue = "100") maxMessages: Int): Mono<GetDlqResult> = Mono.defer { hmppsQueueResource.getDlqMessages(dlqName, maxMessages).let { Mono.just(it) } }
 }

--- a/hmpps-sqs-spring-boot-autoconfigure/src/main/kotlin/uk/gov/justice/hmpps/sqs/HmppsQueueResourceAsync.kt
+++ b/hmpps-sqs-spring-boot-autoconfigure/src/main/kotlin/uk/gov/justice/hmpps/sqs/HmppsQueueResourceAsync.kt
@@ -19,16 +19,16 @@ class HmppsQueueResourceAsync(private val hmppsQueueResource: HmppsQueueResource
 
   @PutMapping("/retry-dlq/{dlqName}")
   @PreAuthorize("hasRole(@environment.getProperty('hmpps.sqs.queueAdminRole', 'ROLE_QUEUE_ADMIN'))")
-  suspend fun retryDlq(@PathVariable("dlqName") dlqName: String) = hmppsQueueResource.retryDlq(dlqName).let { Mono.just(it) }
+  suspend fun retryDlq(@PathVariable("dlqName") dlqName: String): Mono<RetryDlqResult> = hmppsQueueResource.retryDlq(dlqName).let { Mono.just(it) }
 
   @PutMapping("/retry-all-dlqs")
-  suspend fun retryAllDlqs() = hmppsQueueResource.retryAllDlqs().let { Flux.fromIterable(it) }
+  suspend fun retryAllDlqs(): Flux<RetryDlqResult> = hmppsQueueResource.retryAllDlqs().let { Flux.fromIterable(it) }
 
   @PutMapping("/purge-queue/{queueName}")
   @PreAuthorize("hasRole(@environment.getProperty('hmpps.sqs.queueAdminRole', 'ROLE_QUEUE_ADMIN'))")
-  suspend fun purgeQueue(@PathVariable("queueName") queueName: String) = hmppsQueueResource.purgeQueue(queueName).let { Mono.just(it) }
+  suspend fun purgeQueue(@PathVariable("queueName") queueName: String): Mono<PurgeQueueResult> = hmppsQueueResource.purgeQueue(queueName).let { Mono.just(it) }
 
   @GetMapping("/get-dlq-messages/{dlqName}")
   @PreAuthorize("hasRole(@environment.getProperty('hmpps.sqs.queueAdminRole', 'ROLE_QUEUE_ADMIN'))")
-  suspend fun getDlqMessages(@PathVariable("dlqName") dlqName: String, @RequestParam("maxMessages", required = false, defaultValue = "100") maxMessages: Int) = hmppsQueueResource.getDlqMessages(dlqName, maxMessages).let { Mono.just(it) }
+  suspend fun getDlqMessages(@PathVariable("dlqName") dlqName: String, @RequestParam("maxMessages", required = false, defaultValue = "100") maxMessages: Int): Mono<GetDlqResult> = hmppsQueueResource.getDlqMessages(dlqName, maxMessages).let { Mono.just(it) }
 }

--- a/hmpps-sqs-spring-boot-autoconfigure/src/main/kotlin/uk/gov/justice/hmpps/sqs/HmppsSqsConfiguration.kt
+++ b/hmpps-sqs-spring-boot-autoconfigure/src/main/kotlin/uk/gov/justice/hmpps/sqs/HmppsSqsConfiguration.kt
@@ -40,6 +40,10 @@ class HmppsSqsConfiguration {
 
   @Bean
   @ConditionalOnMissingBean
+  fun hmppsQueueResourceAsync(hmppsQueueResource: HmppsQueueResource) = HmppsQueueResourceAsync(hmppsQueueResource)
+
+  @Bean
+  @ConditionalOnMissingBean
   @DependsOn("hmppsQueueService")
   fun hmppsQueueContainerFactoryProxy(factories: List<HmppsQueueDestinationContainerFactory>) = HmppsQueueJmsListenerContainerFactory(factories)
 }


### PR DESCRIPTION
The idea is just to add equivalent asynchronous queue-admin endpoints which are just a wrapper around the synchronous endpoints but returning Mono/Flux types.

Not having done much Kotlin async stuff I'd be interested in your take on the approach.

You can test this by checking out the branch and running command `./gradlew publishToMavenLocal -x :hmpps-sqs-spring-boot-autoconfigure:signAutoconfigurePublication -x :hmpps-sqs-spring-boot-starter:signStarterPublication`, then in the project to test in change the dependency to `implementation("uk.gov.justice.service.hmpps:hmpps-sqs-spring-boot-starter:1.1.7-beta")`