### PR TITLE
SDI-300 reactive queue admin endpoints switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ Hopefully your Open API document generator can find the endpoints automatically 
 
 #### Reactive Queue Admin Endpoints
 
-If you're building an application with Reactive endpoints then your ResourceServer will be configured to support Reactive. This means that you will need Reactive Queue admin endpoints which have path prefix `/queue-admin-async` instead of `/queue-admin`.
+If you're building an application with Reactive endpoints then your ResourceServer will be configured to support Reactive. This means that you will need Reactive Queue admin endpoints which have path prefix `/queue-admin` instead of `/queue-admin`.
 
 To switch to the reactive Queue admin endpoints add configuration `hmpps.sqs.reactiveApi=true` to your configuration properties. Note that this will disable the non-reactive endpoints (which are enabled by default).
 

--- a/README.md
+++ b/README.md
@@ -76,13 +76,14 @@ Examples of property usage can be found in the test project in the following pla
 
 #### HmppsSqsProperties Definitions
 
-| Property | Default | Description |
-| -------- | ------- | ----------- |
-| provider | `aws` | `aws` for production or `localstack` for running locally / integration tests.
-| region   | `eu-west-2` | The AWS region where the queues live. |
+| Property      | Default                 | Description |
+|---------------|-------------------------| ----------- |
+| provider      | `aws`                   | `aws` for production or `localstack` for running locally / integration tests. |
+| region        | `eu-west-2`             | The AWS region where the queues live. |
 | localstackUrl | `http://localhost:4566` | Only used for `provider=localstack`. The location of the running LocalStack instance. |
-| queues   | | A map of `queueId` to `QueueConfig`. One entry is required for each queue. In production these are derived from environment variables with the prefix `HMPPS_SQS_QUEUES_` that should be populated from Kubernetes secrets (see below).
-| topics   | | A map of `topicId` to `TopicConfig`. One entry is required for each topic. In production these are derived from environment variables with the prefix `HMPPS_SQS_TOPICS_` that should be populated from Kubernetes secrets (see below).
+| queues        |                         | A map of `queueId` to `QueueConfig`. One entry is required for each queue. In production these are derived from environment variables with the prefix `HMPPS_SQS_QUEUES_` that should be populated from Kubernetes secrets (see below). |
+| topics        |                         | A map of `topicId` to `TopicConfig`. One entry is required for each topic. In production these are derived from environment variables with the prefix `HMPPS_SQS_TOPICS_` that should be populated from Kubernetes secrets (see below). |
+| reactiveApi   | false                   | Publishes a reactive API for the Queue Admin Endpoints. See [#reactive-queue-admin-endpoints] for more details. |
 
 Each queue declared in the `queues` map is defined in the `QueueConfig` property class
 
@@ -287,6 +288,12 @@ Note that any endpoints defined in `HmppsQueueResource` that are not secured by 
 We do not provide any detailed Open API documentation for these endpoints. This is because there is a variety of Open API document generators being used at different versions and catering for them all would require a complicated solution for little benefit.
 
 Hopefully your Open API document generator can find the endpoints automatically and includes them in the Open API docs. If not you may have to introduce some configuration to point the generator at the endpoints, for example using the Springfox [ApiSelectorBuilder#apis method](https://springfox.github.io/springfox/docs/snapshot/#springfox-spring-mvc-and-spring-boot) to add the base package `uk.gov.justice.hmpps.sqs`.
+
+#### Reactive Queue Admin Endpoints
+
+If you're building an application with Reactive endpoints then your ResourceServer will be configured to support Reactive. This means that you will need Reactive Queue admin endpoints which have path prefix `/queue-admin-async` instead of `/queue-admin`.
+
+To switch to the reactive Queue admin endpoints add configuration `hmpps.sqs.reactiveApi=true` to your configuration properties. Note that this will disable the non-reactive endpoints (which are enabled by default).
 
 ### Testcontainers
 

--- a/README.md
+++ b/README.md
@@ -76,40 +76,40 @@ Examples of property usage can be found in the test project in the following pla
 
 #### HmppsSqsProperties Definitions
 
-| Property      | Default                 | Description |
-|---------------|-------------------------| ----------- |
-| provider      | `aws`                   | `aws` for production or `localstack` for running locally / integration tests. |
-| region        | `eu-west-2`             | The AWS region where the queues live. |
-| localstackUrl | `http://localhost:4566` | Only used for `provider=localstack`. The location of the running LocalStack instance. |
+| Property      | Default                 | Description                                                                                                                                                                                                                             |
+|---------------|-------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| provider      | `aws`                   | `aws` for production or `localstack` for running locally / integration tests.                                                                                                                                                           |
+| region        | `eu-west-2`             | The AWS region where the queues live.                                                                                                                                                                                                   |
+| localstackUrl | `http://localhost:4566` | Only used for `provider=localstack`. The location of the running LocalStack instance.                                                                                                                                                   |
 | queues        |                         | A map of `queueId` to `QueueConfig`. One entry is required for each queue. In production these are derived from environment variables with the prefix `HMPPS_SQS_QUEUES_` that should be populated from Kubernetes secrets (see below). |
 | topics        |                         | A map of `topicId` to `TopicConfig`. One entry is required for each topic. In production these are derived from environment variables with the prefix `HMPPS_SQS_TOPICS_` that should be populated from Kubernetes secrets (see below). |
-| reactiveApi   | false                   | Publishes a reactive API for the Queue Admin Endpoints. See [#reactive-queue-admin-endpoints] for more details. |
+| reactiveApi   | `false`                 | Publishes a reactive API for the Queue Admin Endpoints. See [Reactive Queue Admin Endpoints](#reactive-queue-admin-endpoints) for more details.                                                                                         |
 
 Each queue declared in the `queues` map is defined in the `QueueConfig` property class
 
-| Property | Default | Description |
-| -------- | ------- | ----------- |
-| queueId | | The key to the `queues` map. A unique name for the queue configuration, used heavily when automatically creating Spring beans. Must be lower case. |
-| queueName | | The name of the queue as recognised by AWS or LocalStack. |
-| queueAccessKeyId | | Only used for `provider=aws`. The AWS access key ID, should be derived from an environment variable of format `HMPPS_SQS_QUEUES_<queueId>_QUEUE_ACCESS_KEY_ID`. |
-| queueSecretAccessKey | | Only used for `provider=aws`. The AWS secret access key, should be derived from an environment variable of format `HMPPS_SQS_QUEUES_<queueId>_QUEUE_SECRET_ACCESS_KEY`. |
-| subscribeTopicId | | Only used for `provider=localstack`. The `topicId` of the topic this queue subscribes to when either running integration tests or running locally. |
-| subscribeFilter | | Only used for `provider=localstack`. The filter policy to be applied when subscribing to the topic. Generally used to filter out certain messages. See your queue's `filter_policy` in `cloud-platform-environments` for an example. |
-| asyncQueueClient | `false` | If true then the `AmazonSQS` bean created will be an `AmazonSQSAsync` instance. |
-| dlqName | | The name of the queue's dead letter queue (DLQ) as recognised by AWS or LocalStack. |
-| dlqAccessKeyId | | Only used for `provider=aws`. The AWS access key ID of the DLQ, should be derived from an environment variable of format `HMPPS_SQS_QUEUES_<queueId>_DLQ_ACCESS_KEY_ID`. |
-| dlqSecretAccessKey | | Only used for `provider=aws`. The AWS secret access key of the DLQ, should be derived from an environment variable of format `HMPPS_SQS_QUEUES_<queueId>_DLQ_SECRET_ACCESS_KEY`. |
-| asyncDlqClient | `false` | If true then the `AmazonSQS` bean created will be an `AmazonSQSAsync` instance. |
+| Property             | Default | Description                                                                                                                                                                                                                          |
+|----------------------|---------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| queueId              |         | The key to the `queues` map. A unique name for the queue configuration, used heavily when automatically creating Spring beans. Must be lower case.                                                                                   |
+| queueName            |         | The name of the queue as recognised by AWS or LocalStack.                                                                                                                                                                            |
+| queueAccessKeyId     |         | Only used for `provider=aws`. The AWS access key ID, should be derived from an environment variable of format `HMPPS_SQS_QUEUES_<queueId>_QUEUE_ACCESS_KEY_ID`.                                                                      |
+| queueSecretAccessKey |         | Only used for `provider=aws`. The AWS secret access key, should be derived from an environment variable of format `HMPPS_SQS_QUEUES_<queueId>_QUEUE_SECRET_ACCESS_KEY`.                                                              |
+| subscribeTopicId     |         | Only used for `provider=localstack`. The `topicId` of the topic this queue subscribes to when either running integration tests or running locally.                                                                                   |
+| subscribeFilter      |         | Only used for `provider=localstack`. The filter policy to be applied when subscribing to the topic. Generally used to filter out certain messages. See your queue's `filter_policy` in `cloud-platform-environments` for an example. |
+| asyncQueueClient     | `false` | If true then the `AmazonSQS` bean created will be an `AmazonSQSAsync` instance.                                                                                                                                                      |
+| dlqName              |         | The name of the queue's dead letter queue (DLQ) as recognised by AWS or LocalStack.                                                                                                                                                  |
+| dlqAccessKeyId       |         | Only used for `provider=aws`. The AWS access key ID of the DLQ, should be derived from an environment variable of format `HMPPS_SQS_QUEUES_<queueId>_DLQ_ACCESS_KEY_ID`.                                                             |
+| dlqSecretAccessKey   |         | Only used for `provider=aws`. The AWS secret access key of the DLQ, should be derived from an environment variable of format `HMPPS_SQS_QUEUES_<queueId>_DLQ_SECRET_ACCESS_KEY`.                                                     |
+| asyncDlqClient       | `false` | If true then the `AmazonSQS` bean created will be an `AmazonSQSAsync` instance.                                                                                                                                                      |
 
 Each topic declared in the `topics` map is defined in the `TopicConfig` property class
 
-| Property | Default | Description |
-| -------- | ------- | ----------- |
-| topicId | | The key to the `topics` map. A unique name for the topic configuration, used heavily when automatically creating Spring beans. Must be lower case. |
-| arn | | The ARN of the topic as recognised by AWS and LocalStack. |
-| accessKeyId | | Only used for `provider=aws`. The AWS access key ID, should be derived from an environment variable of format `HMPPS_SQS_TOPICS_<topicId>_ACCESS_KEY_ID`. | 
-| secretAccessKey | | Only used for `provider=aws`. The AWS secret access key, should be derived from an environment variable of format `HMPPS_SQS_TOPICS_<topicId>_SECRET_ACCESS_KEY`. |
-| asyncClient | `false` | If true then the `AmazonSNS` bean created will be an `AmazonSNSAsync` instance. |
+| Property        | Default | Description                                                                                                                                                       |
+|-----------------|---------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| topicId         |         | The key to the `topics` map. A unique name for the topic configuration, used heavily when automatically creating Spring beans. Must be lower case.                |
+| arn             |         | The ARN of the topic as recognised by AWS and LocalStack.                                                                                                         |
+| accessKeyId     |         | Only used for `provider=aws`. The AWS access key ID, should be derived from an environment variable of format `HMPPS_SQS_TOPICS_<topicId>_ACCESS_KEY_ID`.         | 
+| secretAccessKey |         | Only used for `provider=aws`. The AWS secret access key, should be derived from an environment variable of format `HMPPS_SQS_TOPICS_<topicId>_SECRET_ACCESS_KEY`. |
+| asyncClient     | `false` | If true then the `AmazonSNS` bean created will be an `AmazonSNSAsync` instance.                                                                                   |
 
 #### :warning: queueId and topicId Must Be All Lowercase
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 
 allprojects {
   group = "uk.gov.justice.service.hmpps"
-  version = "1.1.8-wip"
+  version = "1.1.8"
 }
 
 nexusPublishing {

--- a/hmpps-sqs-spring-boot-autoconfigure/src/main/kotlin/uk/gov/justice/hmpps/sqs/HmppsQueueResourceAsync.kt
+++ b/hmpps-sqs-spring-boot-autoconfigure/src/main/kotlin/uk/gov/justice/hmpps/sqs/HmppsQueueResourceAsync.kt
@@ -11,10 +11,12 @@ import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.server.ResponseStatusException
 
 /*
- * An asynchronous wrapper around HmppsQueueResource
+ * Warning: This is a duplicate of HmppsQueueResourceAsync but with suspend functions. Therefore, this class should be kept in sync with the non-async class.
+ *
+ * This class *should* just be a wrapper around HmppsQueueResource but that sometimes works and sometimes doesn't! So we're keeping the duplication for now.
  */
 @RestController
-@RequestMapping("/queue-admin-async")
+@RequestMapping("/queue-admin")
 class HmppsQueueResourceAsync(private val hmppsQueueService: HmppsQueueService) {
 
   @PutMapping("/retry-dlq/{dlqName}")

--- a/hmpps-sqs-spring-boot-autoconfigure/src/main/kotlin/uk/gov/justice/hmpps/sqs/HmppsQueueResourceAsync.kt
+++ b/hmpps-sqs-spring-boot-autoconfigure/src/main/kotlin/uk/gov/justice/hmpps/sqs/HmppsQueueResourceAsync.kt
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.server.ResponseStatusException
 
 /*
- * Warning: This is a duplicate of HmppsQueueResourceAsync but with suspend functions. Therefore, this class should be kept in sync with the non-async class.
+ * Warning: This is a duplicate of HmppsQueueResource but with suspend functions. Therefore, this class should be kept in sync with the non-async class.
  *
  * This class *should* just be a wrapper around HmppsQueueResource but that sometimes works and sometimes doesn't! So we're keeping the duplication for now.
  */

--- a/hmpps-sqs-spring-boot-autoconfigure/src/main/kotlin/uk/gov/justice/hmpps/sqs/HmppsSqsConfiguration.kt
+++ b/hmpps-sqs-spring-boot-autoconfigure/src/main/kotlin/uk/gov/justice/hmpps/sqs/HmppsSqsConfiguration.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.hmpps.sqs
 import com.microsoft.applicationinsights.TelemetryClient
 import org.springframework.boot.actuate.autoconfigure.health.HealthEndpointAutoConfiguration
 import org.springframework.boot.autoconfigure.AutoConfigureBefore
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.ConfigurableApplicationContext
@@ -36,10 +37,12 @@ class HmppsSqsConfiguration {
 
   @Bean
   @ConditionalOnMissingBean
+  @ConditionalOnExpression("'\${hmpps.sqs.reactiveApi:false}'.equals('false')")
   fun hmppsQueueResource(hmppsQueueService: HmppsQueueService) = HmppsQueueResource(hmppsQueueService)
 
   @Bean
   @ConditionalOnMissingBean
+  @ConditionalOnExpression("\${hmpps.sqs.reactiveApi:false}")
   fun hmppsQueueResourceAsync(hmppsQueueService: HmppsQueueService) = HmppsQueueResourceAsync(hmppsQueueService)
 
   @Bean

--- a/hmpps-sqs-spring-boot-autoconfigure/src/main/kotlin/uk/gov/justice/hmpps/sqs/HmppsSqsProperties.kt
+++ b/hmpps-sqs-spring-boot-autoconfigure/src/main/kotlin/uk/gov/justice/hmpps/sqs/HmppsSqsProperties.kt
@@ -11,6 +11,7 @@ data class HmppsSqsProperties(
   val localstackUrl: String = "http://localhost:4566",
   val queues: Map<String, QueueConfig> = mapOf(),
   val topics: Map<String, TopicConfig> = mapOf(),
+  val reactiveApi: Boolean = false,
 ) {
   data class QueueConfig(
     val queueName: String,
@@ -127,7 +128,7 @@ data class HmppsSqsProperties(
   private fun <T> mustNotContainDuplicates(description: String, source: Map<String, T>, secret: Boolean = true, valueFinder: (Map.Entry<String, T>) -> String) {
     val duplicateValues = source.mapValues(valueFinder).values.filter { it.isNotEmpty() }.groupingBy { it }.eachCount().filterValues { it > 1 }
     if (duplicateValues.isNotEmpty()) {
-      val outputValues = if (secret.not()) duplicateValues.keys else duplicateValues.keys.map { "${it?.subSequence(0, 4)}******" }.toList()
+      val outputValues = if (secret.not()) duplicateValues.keys else duplicateValues.keys.map { "${it.subSequence(0, 4)}******" }.toList()
       throw InvalidHmppsSqsPropertiesException("Found duplicated $description: $outputValues")
     }
   }

--- a/test-app-async/build.gradle.kts
+++ b/test-app-async/build.gradle.kts
@@ -17,6 +17,11 @@ dependencies {
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4")
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor:1.6.4")
 
+  implementation("org.springdoc:springdoc-openapi-ui:1.6.9")
+  implementation("org.springdoc:springdoc-openapi-webflux-ui:1.6.9")
+  implementation("org.springdoc:springdoc-openapi-kotlin:1.6.9")
+  implementation("org.springdoc:springdoc-openapi-security:1.6.9")
+
   implementation(project(":hmpps-sqs-spring-boot-starter"))
 
   testImplementation("org.assertj:assertj-core:3.23.1")

--- a/test-app-async/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppstemplatepackagenameasync/ReactiveApp.kt
+++ b/test-app-async/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppstemplatepackagenameasync/ReactiveApp.kt
@@ -6,8 +6,8 @@ import org.springframework.boot.runApplication
 
 @SpringBootApplication
 @ConfigurationPropertiesScan
-class HmppsTemplateKotlin
+class ReactiveApp
 
 fun main(args: Array<String>) {
-  runApplication<HmppsTemplateKotlin>(*args)
+  runApplication<ReactiveApp>(*args)
 }

--- a/test-app-async/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppstemplatepackagenameasync/config/OpenApiConfig.kt
+++ b/test-app-async/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppstemplatepackagenameasync/config/OpenApiConfig.kt
@@ -1,0 +1,18 @@
+package uk.gov.justice.digital.hmpps.hmppstemplatepackagenameasync.config
+
+import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.servers.Server
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class OpenApiConfig {
+
+  @Bean
+  fun customOpenAPI(): OpenAPI = OpenAPI()
+    .servers(
+      listOf(
+        Server().url("http://localhost:8080").description("local"),
+      )
+    )
+}

--- a/test-app-async/src/main/resources/logback-spring.xml
+++ b/test-app-async/src/main/resources/logback-spring.xml
@@ -25,7 +25,7 @@
         <appender name="logAppender" class="com.microsoft.applicationinsights.logback.ApplicationInsightsAppender"/>
     </springProfile>
 
-    <logger name="uk.gov.justice.digital.hmpps.hmppstemplatepackagenameasync.HmppsTemplateKotlinKt" additivity="false"
+    <logger name="uk.gov.justice.digital.hmpps.hmppstemplatepackagenameasync.ReactiveAppKt" additivity="false"
             level="DEBUG">
         <appender-ref ref="logAppender"/>
         <appender-ref ref="consoleAppender"/>

--- a/test-app-async/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppstemplatepackagenameasync/integration/HmppsQueueAdminTest.kt
+++ b/test-app-async/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppstemplatepackagenameasync/integration/HmppsQueueAdminTest.kt
@@ -10,7 +10,7 @@ class HmppsQueueAdminTest : IntegrationTestBase() {
   @Test
   fun `should not allow purge with the default role`() {
     webTestClient.put()
-      .uri("/queue-admin-async/purge-queue/${hmppsSqsPropertiesSpy.inboundQueueConfig().dlqName}")
+      .uri("/queue-admin/purge-queue/${hmppsSqsPropertiesSpy.inboundQueueConfig().dlqName}")
       .headers { it.authToken() }
       .accept(MediaType.APPLICATION_JSON)
       .exchange()
@@ -20,7 +20,7 @@ class HmppsQueueAdminTest : IntegrationTestBase() {
   @Test
   fun `should allow purge with custom queue admin role`() {
     webTestClient.put()
-      .uri("/queue-admin-async/purge-queue/${hmppsSqsPropertiesSpy.inboundQueueConfig().dlqName}")
+      .uri("/queue-admin/purge-queue/${hmppsSqsPropertiesSpy.inboundQueueConfig().dlqName}")
       .headers { it.authToken(roles = listOf("ROLE_TEST_APP_QUEUE_ADMIN")) }
       .accept(MediaType.APPLICATION_JSON)
       .exchange()
@@ -30,7 +30,7 @@ class HmppsQueueAdminTest : IntegrationTestBase() {
   @Test
   fun `should not allow retry dlq with the default role`() {
     webTestClient.put()
-      .uri("/queue-admin-async/retry-dlq/${hmppsSqsPropertiesSpy.inboundQueueConfig().dlqName}")
+      .uri("/queue-admin/retry-dlq/${hmppsSqsPropertiesSpy.inboundQueueConfig().dlqName}")
       .headers { it.authToken() }
       .accept(MediaType.APPLICATION_JSON)
       .exchange()
@@ -40,7 +40,7 @@ class HmppsQueueAdminTest : IntegrationTestBase() {
   @Test
   fun `should allow retry dlq with custom queue admin role`() {
     webTestClient.put()
-      .uri("/queue-admin-async/retry-dlq/${hmppsSqsPropertiesSpy.inboundQueueConfig().dlqName}")
+      .uri("/queue-admin/retry-dlq/${hmppsSqsPropertiesSpy.inboundQueueConfig().dlqName}")
       .headers { it.authToken(roles = listOf("ROLE_TEST_APP_QUEUE_ADMIN")) }
       .accept(MediaType.APPLICATION_JSON)
       .exchange()

--- a/test-app-async/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppstemplatepackagenameasync/integration/HmppsQueueResourceTest.kt
+++ b/test-app-async/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppstemplatepackagenameasync/integration/HmppsQueueResourceTest.kt
@@ -23,8 +23,8 @@ class HmppsQueueResourceTest : IntegrationTestBase() {
   inner class SecureEndpoints {
     private fun secureEndpoints() =
       listOf(
-        "/queue-admin-async/retry-dlq/any-queue",
-        "/queue-admin-async/purge-queue/any-queue",
+        "/queue-admin/retry-dlq/any-queue",
+        "/queue-admin/purge-queue/any-queue",
       )
 
     @ParameterizedTest
@@ -54,7 +54,7 @@ class HmppsQueueResourceTest : IntegrationTestBase() {
     @Test
     fun `should fail if dlq not found`() {
       webTestClient.put()
-        .uri("/queue-admin-async/retry-dlq/UNKNOWN_DLQ")
+        .uri("/queue-admin/retry-dlq/UNKNOWN_DLQ")
         .headers { it.authToken() }
         .accept(MediaType.APPLICATION_JSON)
         .exchange()
@@ -72,7 +72,7 @@ class HmppsQueueResourceTest : IntegrationTestBase() {
       await untilCallTo { inboundSqsDlqClient.countMessagesOnQueue(inboundDlqUrl) } matches { it == 2 }
 
       webTestClient.put()
-        .uri("/queue-admin-async/retry-dlq/${hmppsSqsPropertiesSpy.inboundQueueConfig().dlqName}")
+        .uri("/queue-admin/retry-dlq/${hmppsSqsPropertiesSpy.inboundQueueConfig().dlqName}")
         .headers { it.authToken() }
         .accept(MediaType.APPLICATION_JSON)
         .exchange()
@@ -100,7 +100,7 @@ class HmppsQueueResourceTest : IntegrationTestBase() {
       await untilCallTo { outboundSqsDlqClientSpy.countMessagesOnQueue(outboundDlqUrl) } matches { it == 1 }
 
       webTestClient.put()
-        .uri("/queue-admin-async/retry-all-dlqs")
+        .uri("/queue-admin/retry-all-dlqs")
         .headers { it.authToken() }
         .accept(MediaType.APPLICATION_JSON)
         .exchange()
@@ -125,7 +125,7 @@ class HmppsQueueResourceTest : IntegrationTestBase() {
       await untilCallTo { inboundSqsDlqClient.countMessagesOnQueue(inboundDlqUrl) } matches { it == 2 }
 
       webTestClient.put()
-        .uri("/queue-admin-async/purge-queue/${hmppsSqsPropertiesSpy.inboundQueueConfig().dlqName}")
+        .uri("/queue-admin/purge-queue/${hmppsSqsPropertiesSpy.inboundQueueConfig().dlqName}")
         .headers { it.authToken() }
         .accept(MediaType.APPLICATION_JSON)
         .exchange()
@@ -141,7 +141,7 @@ class HmppsQueueResourceTest : IntegrationTestBase() {
       await untilCallTo { outboundSqsDlqClientSpy.countMessagesOnQueue(outboundDlqUrl) } matches { it == 2 }
 
       webTestClient.put()
-        .uri("/queue-admin-async/purge-queue/${hmppsSqsPropertiesSpy.outboundQueueConfig().dlqName}")
+        .uri("/queue-admin/purge-queue/${hmppsSqsPropertiesSpy.outboundQueueConfig().dlqName}")
         .headers { it.authToken() }
         .accept(MediaType.APPLICATION_JSON)
         .exchange()
@@ -160,7 +160,7 @@ class HmppsQueueResourceTest : IntegrationTestBase() {
     @Test
     internal fun `requires a valid authentication token`() {
       webTestClient.get()
-        .uri("/queue-admin-async/get-dlq-messages/any-queue")
+        .uri("/queue-admin/get-dlq-messages/any-queue")
         .exchange()
         .expectStatus().isUnauthorized
     }
@@ -168,7 +168,7 @@ class HmppsQueueResourceTest : IntegrationTestBase() {
     @Test
     internal fun `requires the correct role`() {
       webTestClient.get()
-        .uri("/queue-admin-async/get-dlq-messages/any-queue")
+        .uri("/queue-admin/get-dlq-messages/any-queue")
         .headers { it.authToken(roles = listOf("WRONG_ROLE")) }
         .exchange()
         .expectStatus().isForbidden
@@ -177,7 +177,7 @@ class HmppsQueueResourceTest : IntegrationTestBase() {
     @Test
     fun `should fail if dlq not found`() {
       webTestClient.get()
-        .uri("/queue-admin-async/get-dlq-messages/UNKNOWN_DLQ")
+        .uri("/queue-admin/get-dlq-messages/UNKNOWN_DLQ")
         .headers { it.authToken() }
         .exchange()
         .expectStatus().isNotFound
@@ -191,7 +191,7 @@ class HmppsQueueResourceTest : IntegrationTestBase() {
       await untilCallTo { inboundSqsDlqClient.countMessagesOnQueue(inboundDlqUrl) } matches { it == 3 }
 
       webTestClient.get()
-        .uri("/queue-admin-async/get-dlq-messages/${hmppsSqsPropertiesSpy.inboundQueueConfig().dlqName}")
+        .uri("/queue-admin/get-dlq-messages/${hmppsSqsPropertiesSpy.inboundQueueConfig().dlqName}")
         .headers { it.authToken() }
         .exchange()
         .expectStatus().isOk
@@ -215,7 +215,7 @@ class HmppsQueueResourceTest : IntegrationTestBase() {
       await untilCallTo { inboundSqsDlqClient.countMessagesOnQueue(inboundDlqUrl) } matches { it == 20 }
 
       webTestClient.get()
-        .uri("/queue-admin-async/get-dlq-messages/${hmppsSqsPropertiesSpy.inboundQueueConfig().dlqName}?maxMessages=12")
+        .uri("/queue-admin/get-dlq-messages/${hmppsSqsPropertiesSpy.inboundQueueConfig().dlqName}?maxMessages=12")
         .headers { it.authToken() }
         .exchange()
         .expectStatus().isOk
@@ -227,30 +227,7 @@ class HmppsQueueResourceTest : IntegrationTestBase() {
   }
 
   @Nested
-  inner class NonReactiveApi {
-    @Test
-    fun `should not support non-reactive API`() {
-      webTestClient.put()
-        .uri {
-          it.path("/queue-admin/retry-dlq/{dlqName}")
-            .build(hmppsSqsPropertiesSpy.inboundQueueConfig().dlqName)
-        }
-        .headers { it.authToken() }
-        .accept(MediaType.APPLICATION_JSON)
-        .exchange()
-        .expectStatus().isNotFound
-    }
-
-    @Test
-    fun `should not show the non-reactive API in the Open API docs`() {
-      webTestClient.get()
-        .uri("/v3/api-docs")
-        .accept(MediaType.APPLICATION_JSON)
-        .exchange()
-        .expectStatus().isOk
-        .expectBody().jsonPath("$.paths['/queue-admin/retry-dlq/{dlqName}']").doesNotExist()
-    }
-
+  inner class OpenApiDocs {
     @Test
     fun `should show the reactive API in the Open API docs`() {
       webTestClient.get()
@@ -258,7 +235,8 @@ class HmppsQueueResourceTest : IntegrationTestBase() {
         .accept(MediaType.APPLICATION_JSON)
         .exchange()
         .expectStatus().isOk
-        .expectBody().jsonPath("$.paths['/queue-admin-async/retry-dlq/{dlqName}']").exists()
+        .expectBody()
+        .jsonPath("$.paths['/queue-admin/retry-dlq/{dlqName}'].put.tags[0]").isEqualTo("hmpps-queue-resource-async")
     }
   }
 }

--- a/test-app-async/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppstemplatepackagenameasync/integration/HmppsQueueSpyBeanTest.kt
+++ b/test-app-async/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppstemplatepackagenameasync/integration/HmppsQueueSpyBeanTest.kt
@@ -42,7 +42,7 @@ class HmppsQueueSpyBeanTest : IntegrationTestBase() {
     await untilCallTo { outboundSqsDlqClientSpy.countMessagesOnQueue(outboundDlqUrl) } matches { it == 1 }
 
     webTestClient.put()
-      .uri("/queue-admin-async/retry-dlq/${hmppsSqsPropertiesSpy.outboundQueueConfig().dlqName}")
+      .uri("/queue-admin/retry-dlq/${hmppsSqsPropertiesSpy.outboundQueueConfig().dlqName}")
       .headers { it.authToken() }
       .accept(MediaType.APPLICATION_JSON)
       .exchange()
@@ -70,7 +70,7 @@ class HmppsQueueSpyBeanTest : IntegrationTestBase() {
     await untilCallTo { outboundSqsDlqClientSpy.countMessagesOnQueue(outboundDlqUrl) } matches { it == 1 }
 
     webTestClient.put()
-      .uri("/queue-admin-async/purge-queue/${hmppsSqsPropertiesSpy.outboundQueueConfig().dlqName}")
+      .uri("/queue-admin/purge-queue/${hmppsSqsPropertiesSpy.outboundQueueConfig().dlqName}")
       .headers { it.authToken() }
       .accept(MediaType.APPLICATION_JSON)
       .exchange()

--- a/test-app-async/src/test/resources/application-test.yml
+++ b/test-app-async/src/test/resources/application-test.yml
@@ -6,6 +6,7 @@ management.endpoint:
   info.cache.time-to-live: 0
 
 hmpps.sqs:
+  reactiveApi: true
   provider: localstack
   queues:
     inboundqueue:

--- a/test-app/build.gradle.kts
+++ b/test-app/build.gradle.kts
@@ -13,6 +13,11 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-security")
   implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server")
 
+  implementation("org.springdoc:springdoc-openapi-ui:1.6.9")
+  implementation("org.springdoc:springdoc-openapi-webflux-ui:1.6.9")
+  implementation("org.springdoc:springdoc-openapi-kotlin:1.6.9")
+  implementation("org.springdoc:springdoc-openapi-security:1.6.9")
+
   implementation(project(":hmpps-sqs-spring-boot-starter"))
 
   testImplementation("org.assertj:assertj-core:3.23.1")

--- a/test-app/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppstemplatepackagename/App.kt
+++ b/test-app/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppstemplatepackagename/App.kt
@@ -6,8 +6,8 @@ import org.springframework.boot.runApplication
 
 @SpringBootApplication
 @ConfigurationPropertiesScan
-class HmppsTemplateKotlin
+class App
 
 fun main(args: Array<String>) {
-  runApplication<HmppsTemplateKotlin>(*args)
+  runApplication<App>(*args)
 }

--- a/test-app/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppstemplatepackagename/config/OpenApiConfig.kt
+++ b/test-app/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppstemplatepackagename/config/OpenApiConfig.kt
@@ -1,0 +1,18 @@
+package uk.gov.justice.digital.hmpps.hmppstemplatepackagename.config
+
+import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.servers.Server
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class OpenApiConfig() {
+
+  @Bean
+  fun customOpenAPI(): OpenAPI = OpenAPI()
+    .servers(
+      listOf(
+        Server().url("http://localhost:8080").description("local"),
+      )
+    )
+}

--- a/test-app/src/main/resources/logback-spring.xml
+++ b/test-app/src/main/resources/logback-spring.xml
@@ -25,7 +25,7 @@
         <appender name="logAppender" class="com.microsoft.applicationinsights.logback.ApplicationInsightsAppender"/>
     </springProfile>
 
-    <logger name="uk.gov.justice.digital.hmpps.hmppstemplatepackagename.HmppsTemplateKotlinKt" additivity="false"
+    <logger name="uk.gov.justice.digital.hmpps.hmppstemplatepackagename.AppKt" additivity="false"
             level="DEBUG">
         <appender-ref ref="logAppender"/>
         <appender-ref ref="consoleAppender"/>

--- a/test-app/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppstemplatepackagename/integration/HmppsQueueResourceTest.kt
+++ b/test-app/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppstemplatepackagename/integration/HmppsQueueResourceTest.kt
@@ -251,30 +251,7 @@ class HmppsQueueResourceTest : IntegrationTestBase() {
   }
 
   @Nested
-  inner class ReactiveApi {
-    @Test
-    fun `should not support reactive API by default`() {
-      webTestClient.put()
-        .uri {
-          it.path("/queue-admin-async/retry-dlq/{dlqName}")
-            .build(hmppsSqsPropertiesSpy.inboundQueueConfig().dlqName)
-        }
-        .headers { it.authToken() }
-        .accept(MediaType.APPLICATION_JSON)
-        .exchange()
-        .expectStatus().isNotFound
-    }
-
-    @Test
-    fun `should not show the reactive API in the Open API docs`() {
-      webTestClient.get()
-        .uri("/v3/api-docs")
-        .accept(MediaType.APPLICATION_JSON)
-        .exchange()
-        .expectStatus().isOk
-        .expectBody().jsonPath("$.paths['/queue-admin-async/retry-dlq/{dlqName}']").doesNotExist()
-    }
-
+  inner class OpenApiDocs {
     @Test
     fun `should show the non-reactive API in the Open API docs`() {
       webTestClient.get()
@@ -282,7 +259,8 @@ class HmppsQueueResourceTest : IntegrationTestBase() {
         .accept(MediaType.APPLICATION_JSON)
         .exchange()
         .expectStatus().isOk
-        .expectBody().jsonPath("$.paths['/queue-admin/retry-dlq/{dlqName}']").exists()
+        .expectBody()
+        .jsonPath("$.paths['/queue-admin/retry-dlq/{dlqName}'].put.tags[0]").isEqualTo("hmpps-queue-resource")
     }
   }
 }

--- a/test-app/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppstemplatepackagename/integration/HmppsQueueResourceTest.kt
+++ b/test-app/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppstemplatepackagename/integration/HmppsQueueResourceTest.kt
@@ -249,4 +249,40 @@ class HmppsQueueResourceTest : IntegrationTestBase() {
         .jsonPath("$..messages.length()").isEqualTo(12)
     }
   }
+
+  @Nested
+  inner class ReactiveApi {
+    @Test
+    fun `should not support reactive API by default`() {
+      webTestClient.put()
+        .uri {
+          it.path("/queue-admin-async/retry-dlq/{dlqName}")
+            .build(hmppsSqsPropertiesSpy.inboundQueueConfig().dlqName)
+        }
+        .headers { it.authToken() }
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus().isNotFound
+    }
+
+    @Test
+    fun `should not show the reactive API in the Open API docs`() {
+      webTestClient.get()
+        .uri("/v3/api-docs")
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus().isOk
+        .expectBody().jsonPath("$.paths['/queue-admin-async/retry-dlq/{dlqName}']").doesNotExist()
+    }
+
+    @Test
+    fun `should show the non-reactive API in the Open API docs`() {
+      webTestClient.get()
+        .uri("/v3/api-docs")
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus().isOk
+        .expectBody().jsonPath("$.paths['/queue-admin/retry-dlq/{dlqName}']").exists()
+    }
+  }
 }


### PR DESCRIPTION
Introduce a configuration property that turns on either the async queue admin endpoints (to support reactive apps) or the non-async endpoints for other apps.