### PR TITLE
SDI-318 Make the async queue service fully asynchronous

### DIFF
--- a/hmpps-sqs-spring-boot-autoconfigure/src/main/kotlin/uk/gov/justice/hmpps/sqs/HmppsAsyncQueueService.kt
+++ b/hmpps-sqs-spring-boot-autoconfigure/src/main/kotlin/uk/gov/justice/hmpps/sqs/HmppsAsyncQueueService.kt
@@ -3,15 +3,18 @@ package uk.gov.justice.hmpps.sqs
 import com.google.gson.GsonBuilder
 import com.google.gson.ToNumberPolicy
 import com.microsoft.applicationinsights.TelemetryClient
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.mapNotNull
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.future.await
 import org.slf4j.LoggerFactory
 import software.amazon.awssdk.services.sqs.SqsAsyncClient
 import software.amazon.awssdk.services.sqs.model.DeleteMessageRequest
 import software.amazon.awssdk.services.sqs.model.GetQueueAttributesRequest
-import software.amazon.awssdk.services.sqs.model.Message
 import software.amazon.awssdk.services.sqs.model.QueueAttributeName
 import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest
 import software.amazon.awssdk.services.sqs.model.SendMessageRequest
-import kotlin.coroutines.suspendCoroutine
 import kotlin.math.min
 import software.amazon.awssdk.services.sqs.model.PurgeQueueRequest as AwsPurgeQueueRequest
 
@@ -25,7 +28,6 @@ open class HmppsAsyncQueueService(
   private companion object {
     private val log = LoggerFactory.getLogger(this::class.java)
     private val gson = GsonBuilder().setObjectToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE).create()
-    private val mapClassType = mapOf<String, Any>().javaClass
   }
 
   private val hmppsAsyncTopics: List<HmppsAsyncTopic> = hmppsAsyncTopicFactory.createHmppsAsyncTopics(hmppsSqsProperties)
@@ -49,44 +51,41 @@ open class HmppsAsyncQueueService(
       .map { retryDlqRequest -> retryDlqMessages(retryDlqRequest) }
 
   private suspend fun HmppsAsyncQueue.retryDlqMessages(): RetryDlqResult {
-    if (sqsAsyncDlqClient == null || dlqUrl == null) return RetryDlqResult(0, mutableListOf())
+    if (sqsAsyncDlqClient == null || dlqUrl == null) return RetryDlqResult(0, listOf())
     val messageCount = sqsAsyncDlqClient.countMessagesOnQueue(dlqUrl!!)
-    val messages = mutableListOf<Message.Builder>()
-    repeat(messageCount) {
-      sqsAsyncDlqClient.receiveMessage(ReceiveMessageRequest.builder().queueUrl(dlqUrl).maxNumberOfMessages(1).attributeNames(QueueAttributeName.ALL).build())
-        .thenApply { it.messages().firstOrNull() }
-        .thenApply { msg ->
-          msg?.run {
-            sqsAsyncClient.sendMessage(SendMessageRequest.builder().queueUrl(queueUrl).messageBody(msg.body()).messageAttributes(msg.messageAttributes()).build())
-            sqsAsyncDlqClient.deleteMessage(DeleteMessageRequest.builder().queueUrl(dlqUrl).receiptHandle(msg.receiptHandle()).build())
-            messages += msg.toBuilder()
-          }
-        }
-    }
+    val map: Map<String, Any> = HashMap()
+
+    val messages = (1..messageCount)
+      .map { sqsAsyncDlqClient.receiveMessage(ReceiveMessageRequest.builder().queueUrl(dlqUrl).maxNumberOfMessages(1).attributeNames(QueueAttributeName.ALL).build()).await() }
+      .mapNotNull { it.messages().firstOrNull() }
+      .map { msg ->
+        sqsAsyncClient.sendMessage(SendMessageRequest.builder().queueUrl(queueUrl).messageBody(msg.body()).messageAttributes(msg.messageAttributes()).build())
+        sqsAsyncDlqClient.deleteMessage(DeleteMessageRequest.builder().queueUrl(dlqUrl).receiptHandle(msg.receiptHandle()).build())
+        DlqMessage(messageId = msg.messageId(), body = gson.fromJson(msg.body(), map.javaClass))
+      }
+
     messageCount.takeIf { it > 0 }
       ?.also { log.info("For dlq ${this.dlqName} we found $messageCount messages, attempted to retry ${messages.size}") }
       ?.also { telemetryClient?.trackEvent("RetryDLQ", mapOf("dlq-name" to dlqName, "messages-found" to "$messageCount", "messages-retried" to "${messages.size}"), null) }
-    return RetryDlqResult(messageCount, messages.toList())
+
+    return RetryDlqResult(messageCount, messages)
   }
 
   private suspend fun HmppsAsyncQueue.getDlqMessages(maxMessages: Int): GetDlqResult {
     if (sqsAsyncDlqClient == null || dlqUrl == null) return GetDlqResult(0, 0, listOf())
 
-    val messages = mutableListOf<DlqMessage>()
     val messageCount = sqsAsyncDlqClient.countMessagesOnQueue(dlqUrl!!)
     val messagesToReturnCount = min(messageCount, maxMessages)
+    val map: Map<String, Any> = HashMap()
 
-    (1..messagesToReturnCount).map {
-      sqsAsyncDlqClient.receiveMessage(ReceiveMessageRequest.builder().queueUrl(dlqUrl).maxNumberOfMessages(1).build())
-        .thenApply { it.messages().firstOrNull() }
-        .thenApply { msg ->
-          msg?.run {
-            messages += DlqMessage(messageId = msg.messageId(), body = gson.fromJson(msg.body(), mapClassType))
-          }
-        }
-    }.toTypedArray()
-    // CompletableFuture.allOf(*messageFutures) TODO do I need this? Or does suspend magic just work and I can switch back to repeat(messagesToReturnCount)?
-    return GetDlqResult(messageCount, messagesToReturnCount, messages.toList())
+    val messages = (1..messagesToReturnCount)
+      .asFlow()
+      .map { sqsAsyncDlqClient.receiveMessage(ReceiveMessageRequest.builder().queueUrl(dlqUrl).maxNumberOfMessages(1).build()).await() }
+      .mapNotNull { it.messages().firstOrNull() }
+      .map { msg -> DlqMessage(messageId = msg.messageId(), body = gson.fromJson(msg.body(), map.javaClass)) }
+      .toList()
+
+    return GetDlqResult(messageCount, messagesToReturnCount, messages)
   }
 
   open suspend fun purgeQueue(request: PurgeAsyncQueueRequest): PurgeQueueResult =
@@ -110,11 +109,11 @@ open class HmppsAsyncQueueService(
 data class RetryAsyncDlqRequest(val hmppsQueue: HmppsAsyncQueue)
 
 data class GetAsyncDlqRequest(val hmppsQueue: HmppsAsyncQueue, val maxMessages: Int)
-
 data class PurgeAsyncQueueRequest(val queueName: String, val sqsClient: SqsAsyncClient, val queueUrl: String)
 
 internal suspend fun SqsAsyncClient.countMessagesOnQueue(queueUrl: String): Int =
-  suspendCoroutine {
-    this.getQueueAttributes(GetQueueAttributesRequest.builder().queueUrl(queueUrl).attributeNames(QueueAttributeName.APPROXIMATE_NUMBER_OF_MESSAGES).build())
-      .thenApply { it.attributes()[QueueAttributeName.APPROXIMATE_NUMBER_OF_MESSAGES]?.toInt() ?: 0 }
-  }
+  this.getQueueAttributes(GetQueueAttributesRequest.builder().queueUrl(queueUrl).attributeNames(QueueAttributeName.APPROXIMATE_NUMBER_OF_MESSAGES).build())
+    .await()
+    .let {
+      it.attributes()[QueueAttributeName.APPROXIMATE_NUMBER_OF_MESSAGES]?.toInt() ?: 0
+    }

--- a/hmpps-sqs-spring-boot-autoconfigure/src/test/kotlin/uk/gov/justice/hmpps/sqs/HmppsAsyncQueueServiceTest.kt
+++ b/hmpps-sqs-spring-boot-autoconfigure/src/test/kotlin/uk/gov/justice/hmpps/sqs/HmppsAsyncQueueServiceTest.kt
@@ -1,0 +1,709 @@
+package uk.gov.justice.hmpps.sqs
+
+import com.microsoft.applicationinsights.TelemetryClient
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.check
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.isNull
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoMoreInteractions
+import org.mockito.kotlin.whenever
+import software.amazon.awssdk.services.sqs.SqsAsyncClient
+import software.amazon.awssdk.services.sqs.model.DeleteMessageRequest
+import software.amazon.awssdk.services.sqs.model.GetQueueAttributesRequest
+import software.amazon.awssdk.services.sqs.model.GetQueueAttributesResponse
+import software.amazon.awssdk.services.sqs.model.GetQueueUrlRequest
+import software.amazon.awssdk.services.sqs.model.GetQueueUrlResponse
+import software.amazon.awssdk.services.sqs.model.Message
+import software.amazon.awssdk.services.sqs.model.MessageAttributeValue
+import software.amazon.awssdk.services.sqs.model.QueueAttributeName
+import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest
+import software.amazon.awssdk.services.sqs.model.ReceiveMessageResponse
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest
+import java.util.concurrent.CompletableFuture
+
+class HmppsAsyncQueueServiceTest {
+
+  private val telemetryClient = mock<TelemetryClient>()
+  private val hmppsAsyncTopicFactory = mock<HmppsAsyncTopicFactory>()
+  private val hmppsAsyncQueueFactory = mock<HmppsAsyncQueueFactory>()
+  private val hmppsSqsProperties = mock<HmppsSqsProperties>()
+  private lateinit var hmppsAsyncQueueService: HmppsAsyncQueueService
+
+  @Nested
+  inner class HmppsQueues {
+
+    private val sqsAsyncClient = mock<SqsAsyncClient>()
+    private val sqsAsyncDlqClient = mock<SqsAsyncClient>()
+
+    @BeforeEach
+    fun `add test data`() {
+      whenever(sqsAsyncClient.getQueueUrl(any<GetQueueUrlRequest>()))
+        .thenReturn(CompletableFuture.completedFuture(GetQueueUrlResponse.builder().queueUrl("some queue url").build()))
+      whenever(sqsAsyncDlqClient.getQueueUrl(any<GetQueueUrlRequest>()))
+        .thenReturn(CompletableFuture.completedFuture(GetQueueUrlResponse.builder().queueUrl("some dlq url").build()))
+      whenever(hmppsAsyncQueueFactory.createHmppsAsyncQueues(any(), any()))
+        .thenReturn(
+          listOf(
+            HmppsAsyncQueue("some queue id", sqsAsyncClient, "some queue name", sqsAsyncDlqClient, "some dlq name"),
+            HmppsAsyncQueue("another queue id", mock(), "another queue name", mock(), "another dlq name"),
+          )
+        )
+
+      hmppsAsyncQueueService = HmppsAsyncQueueService(telemetryClient, hmppsAsyncTopicFactory, hmppsAsyncQueueFactory, hmppsSqsProperties)
+    }
+
+    @Test
+    fun `finds an hmpps queue by queue id`() {
+      assertThat(hmppsAsyncQueueService.findByQueueId("some queue id")?.queueUrl).isEqualTo("some queue url")
+    }
+
+    @Test
+    fun `finds an hmpps queue by queue name`() {
+      assertThat(hmppsAsyncQueueService.findByQueueName("some queue name")?.queueUrl).isEqualTo("some queue url")
+    }
+
+    @Test
+    fun `finds an hmpps queue by dlq name`() {
+      assertThat(hmppsAsyncQueueService.findByDlqName("some dlq name")?.dlqUrl).isEqualTo("some dlq url")
+    }
+
+    @Test
+    fun `returns null if queue id not found`() {
+      assertThat(hmppsAsyncQueueService.findByQueueId("unknown")).isNull()
+    }
+
+    @Test
+    fun `returns null if queue not found`() {
+      assertThat(hmppsAsyncQueueService.findByQueueName("unknown")).isNull()
+    }
+
+    @Test
+    fun `returns null if dlq not found`() {
+      assertThat(hmppsAsyncQueueService.findByDlqName("unknown")).isNull()
+    }
+  }
+
+  @Nested
+  inner class RetryDlqMessages {
+
+    private val dlqSqs = mock<SqsAsyncClient>()
+    private val queueSqs = mock<SqsAsyncClient>()
+
+    @BeforeEach
+    fun `stub getting of queue url`() {
+      whenever(queueSqs.getQueueUrl(any<GetQueueUrlRequest>()))
+        .thenReturn(CompletableFuture.completedFuture(GetQueueUrlResponse.builder().queueUrl("queueUrl").build()))
+      whenever(dlqSqs.getQueueUrl(any<GetQueueUrlRequest>()))
+        .thenReturn(CompletableFuture.completedFuture(GetQueueUrlResponse.builder().queueUrl("dlqUrl").build()))
+
+      hmppsAsyncQueueService = HmppsAsyncQueueService(telemetryClient, hmppsAsyncTopicFactory, hmppsAsyncQueueFactory, hmppsSqsProperties)
+    }
+
+    @Nested
+    inner class NoMessages {
+      @BeforeEach
+      fun `finds zero messages on dlq`() {
+        whenever(dlqSqs.getQueueAttributes(any<GetQueueAttributesRequest>())).thenReturn(
+          CompletableFuture.completedFuture(GetQueueAttributesResponse.builder().attributes(mapOf(QueueAttributeName.APPROXIMATE_NUMBER_OF_MESSAGES to "0")).build())
+        )
+      }
+
+      @Test
+      fun `should not attempt any transfer`() = runBlocking<Unit> {
+        hmppsAsyncQueueService.retryDlqMessages(
+          RetryAsyncDlqRequest(HmppsAsyncQueue("some queue id", queueSqs, "some queue name", dlqSqs, "some dlq name"))
+        )
+
+        verify(dlqSqs).getQueueAttributes(
+          GetQueueAttributesRequest.builder()
+            .queueUrl("dlqUrl").attributeNames(QueueAttributeName.APPROXIMATE_NUMBER_OF_MESSAGES).build()
+        )
+        verify(dlqSqs, times(0)).receiveMessage(any<ReceiveMessageRequest>())
+      }
+
+      @Test
+      fun `should return empty result`() = runBlocking<Unit> {
+        val result =
+          hmppsAsyncQueueService.retryDlqMessages(
+            RetryAsyncDlqRequest(HmppsAsyncQueue("some queue id", queueSqs, "some queue name", dlqSqs, "some dlq name"))
+          )
+
+        assertThat(result.messagesFoundCount).isEqualTo(0)
+        assertThat(result.messages).asList().isEmpty()
+      }
+
+      @Test
+      fun `should not create telemetry event`() = runBlocking<Unit> {
+        hmppsAsyncQueueService.retryDlqMessages(
+          RetryAsyncDlqRequest(HmppsAsyncQueue("some queue id", queueSqs, "some queue name", dlqSqs, "some dlq name"))
+        )
+
+        verifyNoMoreInteractions(telemetryClient)
+      }
+    }
+
+    @Nested
+    inner class SingleMessage {
+      @BeforeEach
+      fun `finds a single message on the dlq`() {
+        whenever(dlqSqs.getQueueAttributes(any<GetQueueAttributesRequest>())).thenReturn(
+          CompletableFuture.completedFuture(GetQueueAttributesResponse.builder().attributes(mapOf(QueueAttributeName.APPROXIMATE_NUMBER_OF_MESSAGES to "1")).build())
+        )
+        whenever(dlqSqs.receiveMessage(any<ReceiveMessageRequest>()))
+          .thenReturn(
+            CompletableFuture.completedFuture(
+              ReceiveMessageResponse.builder().messages(
+                Message.builder()
+                  .body(
+                    """
+                    {
+                      "Message":{
+                        "id":"event-id",
+                        "contents":"event-contents",
+                        "longProperty":12345678
+                      },
+                      "MessageId":"message-id-1"
+                    }
+                    """.trimIndent()
+                  )
+                  .receiptHandle("message-receipt-handle")
+                  .messageId("external-message-id-1")
+                  .messageAttributes(mutableMapOf("some" to stringAttributeOf("attribute")))
+                  .build()
+              ).build()
+            )
+          )
+
+        hmppsAsyncQueueService = HmppsAsyncQueueService(telemetryClient, hmppsAsyncTopicFactory, hmppsAsyncQueueFactory, hmppsSqsProperties)
+      }
+
+      @Test
+      fun `should receive message from the dlq`() = runBlocking<Unit> {
+        hmppsAsyncQueueService.retryDlqMessages(
+          RetryAsyncDlqRequest(HmppsAsyncQueue("some queue id", queueSqs, "some queue name", dlqSqs, "some dlq name"))
+        )
+
+        verify(dlqSqs).receiveMessage(
+          check<ReceiveMessageRequest> {
+            assertThat(it.queueUrl()).isEqualTo("dlqUrl")
+            assertThat(it.maxNumberOfMessages()).isEqualTo(1)
+          }
+        )
+      }
+
+      @Test
+      fun `should delete message from the dlq`() = runBlocking<Unit> {
+        hmppsAsyncQueueService.retryDlqMessages(
+          RetryAsyncDlqRequest(HmppsAsyncQueue("some queue id", queueSqs, "some queue name", dlqSqs, "some dlq name"))
+        )
+
+        verify(dlqSqs).deleteMessage(
+          check<DeleteMessageRequest> {
+            assertThat(it.queueUrl()).isEqualTo("dlqUrl")
+            assertThat(it.receiptHandle()).isEqualTo("message-receipt-handle")
+          }
+        )
+      }
+
+      @Test
+      fun `should send message to the main queue`() = runBlocking<Unit> {
+        hmppsAsyncQueueService.retryDlqMessages(
+          RetryAsyncDlqRequest(HmppsAsyncQueue("some queue id", queueSqs, "some queue name", dlqSqs, "some dlq name"))
+        )
+        verify(queueSqs).sendMessage(
+          check<SendMessageRequest> {
+            assertThat(it.queueUrl()).isEqualTo("queueUrl")
+            assertThat(it.messageBody()).isNotEmpty
+            assertThat(it.messageAttributes()).containsEntry("some", stringAttributeOf("attribute"))
+          }
+        )
+      }
+
+      @Test
+      fun `should return the message`() = runBlocking<Unit> {
+        val result = hmppsAsyncQueueService.retryDlqMessages(
+          RetryAsyncDlqRequest(HmppsAsyncQueue("some queue id", queueSqs, "some queue name", dlqSqs, "some dlq name"))
+        )
+
+        assertThat(result.messagesFoundCount).isEqualTo(1)
+        assertThat(result.messages[0].messageId).isEqualTo("external-message-id-1")
+        assertThat(result.messages[0].body["Message"]).isNotNull
+      }
+
+      @Test
+      fun `should create telemetry event`() = runBlocking<Unit> {
+        hmppsAsyncQueueService.retryDlqMessages(
+          RetryAsyncDlqRequest(HmppsAsyncQueue("some queue id", queueSqs, "some queue name", dlqSqs, "some dlq name"))
+        )
+
+        verify(telemetryClient).trackEvent(
+          eq("RetryDLQ"),
+          check {
+            assertThat(it).containsEntry("dlq-name", "some dlq name")
+            assertThat(it).containsEntry("messages-found", "1")
+            assertThat(it).containsEntry("messages-retried", "1")
+          },
+          isNull()
+        )
+      }
+    }
+
+    @Nested
+    inner class MultipleMessages {
+      @BeforeEach
+      fun `finds two message on the dlq`() {
+        whenever(dlqSqs.getQueueAttributes(any<GetQueueAttributesRequest>())).thenReturn(
+          CompletableFuture.completedFuture(
+            GetQueueAttributesResponse.builder().attributes(mapOf(QueueAttributeName.APPROXIMATE_NUMBER_OF_MESSAGES to "2")).build()
+          )
+        )
+        whenever(dlqSqs.receiveMessage(any<ReceiveMessageRequest>()))
+          .thenReturn(
+            CompletableFuture.completedFuture(
+              ReceiveMessageResponse.builder().messages(
+                Message.builder()
+                  .body(
+                    """
+                    {
+                      "Message":{
+                        "id":"event-id",
+                        "contents":"event-contents",
+                        "longProperty":12345678
+                      },
+                      "MessageId":"message-id-1"
+                    }
+                    """.trimIndent()
+                  )
+                  .receiptHandle("message-1-receipt-handle")
+                  .messageId("external-message-id-1")
+                  .messageAttributes(mutableMapOf("some" to stringAttributeOf("attribute-1")))
+                  .build()
+              ).build()
+            )
+          )
+          .thenReturn(
+            CompletableFuture.completedFuture(
+              ReceiveMessageResponse.builder().messages(
+                Message.builder()
+                  .body(
+                    """
+                    {
+                      "Message":{
+                        "id":"event-id",
+                        "contents":"event-contents",
+                        "longProperty":12345678
+                      },
+                      "MessageId":"message-id-2"
+                    }
+                    """.trimIndent()
+                  )
+                  .receiptHandle("message-2-receipt-handle")
+                  .messageId("external-message-id-2")
+                  .messageAttributes(mutableMapOf("some" to stringAttributeOf("attribute-2")))
+                  .build()
+              ).build()
+            )
+          )
+
+        hmppsAsyncQueueService = HmppsAsyncQueueService(telemetryClient, hmppsAsyncTopicFactory, hmppsAsyncQueueFactory, hmppsSqsProperties)
+      }
+
+      @Test
+      fun `should receive message from the dlq`() = runBlocking<Unit> {
+        hmppsAsyncQueueService.retryDlqMessages(
+          RetryAsyncDlqRequest(HmppsAsyncQueue("some queue id", queueSqs, "some queue name", dlqSqs, "some dlq name"))
+        )
+
+        verify(dlqSqs, times(2)).receiveMessage(
+          check<ReceiveMessageRequest> {
+            assertThat(it.queueUrl()).isEqualTo("dlqUrl")
+            assertThat(it.maxNumberOfMessages()).isEqualTo(1)
+          }
+        )
+      }
+
+      @Test
+      fun `should delete message from the dlq`() = runBlocking<Unit> {
+        hmppsAsyncQueueService.retryDlqMessages(
+          RetryAsyncDlqRequest(HmppsAsyncQueue("some queue id", queueSqs, "some queue name", dlqSqs, "some dlq name"))
+        )
+
+        val captor = argumentCaptor<DeleteMessageRequest>()
+        verify(dlqSqs, times(2)).deleteMessage(captor.capture())
+
+        assertThat(captor.firstValue.receiptHandle()).isEqualTo("message-1-receipt-handle")
+        assertThat(captor.secondValue.receiptHandle()).isEqualTo("message-2-receipt-handle")
+      }
+
+      @Test
+      fun `should send message to the main queue`() = runBlocking<Unit> {
+        hmppsAsyncQueueService.retryDlqMessages(
+          RetryAsyncDlqRequest(HmppsAsyncQueue("some queue id", queueSqs, "some queue name", dlqSqs, "some dlq name"))
+        )
+
+        val captor = argumentCaptor<SendMessageRequest>()
+        verify(queueSqs, times(2)).sendMessage(captor.capture())
+
+        assertThat(captor.firstValue.queueUrl()).isEqualTo("queueUrl")
+        assertThat(captor.firstValue.messageBody()).contains("message-id-1")
+        assertThat((captor.firstValue.messageAttributes()["some"] as MessageAttributeValue).stringValue()).isEqualTo("attribute-1")
+        assertThat(captor.secondValue.queueUrl()).isEqualTo("queueUrl")
+        assertThat(captor.secondValue.messageBody()).contains("message-id-2")
+        assertThat((captor.secondValue.messageAttributes()["some"] as MessageAttributeValue).stringValue()).isEqualTo("attribute-2")
+      }
+
+      @Test
+      fun `should return the message`() = runBlocking<Unit> {
+        val result = hmppsAsyncQueueService.retryDlqMessages(
+          RetryAsyncDlqRequest(HmppsAsyncQueue("some queue id", queueSqs, "some queue name", dlqSqs, "some dlq name"))
+        )
+
+        assertThat(result.messagesFoundCount).isEqualTo(2)
+        assertThat(result.messages[0].messageId).isEqualTo("external-message-id-1")
+        assertThat(result.messages[0].body["Message"]).isNotNull
+        assertThat(result.messages[1].messageId).isEqualTo("external-message-id-2")
+        assertThat(result.messages[1].body["Message"]).isNotNull
+      }
+    }
+
+    @Nested
+    inner class MultipleMessagesSomeNotFound {
+      @BeforeEach
+      fun `finds only one of two message on the dlq`() {
+        whenever(dlqSqs.getQueueAttributes(any<GetQueueAttributesRequest>())).thenReturn(
+          CompletableFuture.completedFuture(
+            GetQueueAttributesResponse.builder().attributes(mapOf(QueueAttributeName.APPROXIMATE_NUMBER_OF_MESSAGES to "2")).build()
+          )
+        )
+        whenever(dlqSqs.receiveMessage(any<ReceiveMessageRequest>())).thenReturn(
+          CompletableFuture.completedFuture(
+            ReceiveMessageResponse.builder().messages(
+              Message.builder()
+                .body(
+                  """
+                    {
+                      "Message":{
+                        "id":"event-id",
+                        "contents":"event-contents",
+                        "longProperty":12345678
+                      },
+                      "MessageId":"message-id-1"
+                    }
+                  """.trimIndent()
+                )
+                .receiptHandle("message-1-receipt-handle")
+                .messageId("external-message-id-1")
+                .messageAttributes(mutableMapOf("some" to stringAttributeOf("attribute-1")))
+                .build()
+            ).build()
+          )
+        )
+          .thenReturn(CompletableFuture.completedFuture(ReceiveMessageResponse.builder().build()))
+
+        hmppsAsyncQueueService = HmppsAsyncQueueService(telemetryClient, hmppsAsyncTopicFactory, hmppsAsyncQueueFactory, hmppsSqsProperties)
+      }
+
+      @Test
+      fun `should receive message from the dlq`() = runBlocking<Unit> {
+        hmppsAsyncQueueService.retryDlqMessages(
+          RetryAsyncDlqRequest(HmppsAsyncQueue("some queue id", queueSqs, "some queue name", dlqSqs, "some dlq name"))
+        )
+
+        verify(dlqSqs, times(2)).receiveMessage(
+          check<ReceiveMessageRequest> {
+            assertThat(it.queueUrl()).isEqualTo("dlqUrl")
+            assertThat(it.maxNumberOfMessages()).isEqualTo(1)
+          }
+        )
+      }
+
+      @Test
+      fun `should delete message from the dlq`() = runBlocking<Unit> {
+        hmppsAsyncQueueService.retryDlqMessages(
+          RetryAsyncDlqRequest(HmppsAsyncQueue("some queue id", queueSqs, "some queue name", dlqSqs, "some dlq name"))
+        )
+
+        val captor = argumentCaptor<DeleteMessageRequest>()
+        verify(dlqSqs).deleteMessage(captor.capture())
+
+        assertThat(captor.firstValue.receiptHandle()).isEqualTo("message-1-receipt-handle")
+      }
+
+      @Test
+      fun `should send message to the main queue`() = runBlocking<Unit> {
+        hmppsAsyncQueueService.retryDlqMessages(
+          RetryAsyncDlqRequest(HmppsAsyncQueue("some queue id", queueSqs, "some queue name", dlqSqs, "some dlq name"))
+        )
+
+        val captor = argumentCaptor<SendMessageRequest>()
+        verify(queueSqs).sendMessage(captor.capture())
+
+        assertThat(captor.firstValue.queueUrl()).isEqualTo("queueUrl")
+        assertThat(captor.firstValue.messageBody()).contains("message-id-1")
+        assertThat((captor.firstValue.messageAttributes()["some"] as MessageAttributeValue).stringValue()).isEqualTo("attribute-1")
+      }
+
+      @Test
+      fun `should return the message`() = runBlocking<Unit> {
+        val result = hmppsAsyncQueueService.retryDlqMessages(
+          RetryAsyncDlqRequest(HmppsAsyncQueue("some queue id", queueSqs, "some queue name", dlqSqs, "some dlq name"))
+        )
+
+        assertThat(result.messagesFoundCount).isEqualTo(2)
+        assertThat(result.messages[0].messageId).isEqualTo("external-message-id-1")
+        assertThat(result.messages[0].body["Message"]).isNotNull
+      }
+
+      @Test
+      fun `should create telemetry event`() = runBlocking<Unit> {
+        hmppsAsyncQueueService.retryDlqMessages(
+          RetryAsyncDlqRequest(HmppsAsyncQueue("some queue id", queueSqs, "some queue name", dlqSqs, "some dlq name"))
+        )
+
+        verify(telemetryClient).trackEvent(
+          eq("RetryDLQ"),
+          check {
+            assertThat(it).containsEntry("dlq-name", "some dlq name")
+            assertThat(it).containsEntry("messages-found", "2")
+            assertThat(it).containsEntry("messages-retried", "1")
+          },
+          isNull()
+        )
+      }
+    }
+  }
+
+  @Nested
+  inner class GetDlqMessages {
+    private val dlqSqs = mock<SqsAsyncClient>()
+    private val queueSqs = mock<SqsAsyncClient>()
+
+    @BeforeEach
+    fun `stub getting of queue url`() {
+      whenever(queueSqs.getQueueUrl(any<GetQueueUrlRequest>())).thenReturn(
+        CompletableFuture.completedFuture(GetQueueUrlResponse.builder().queueUrl("queueUrl").build())
+      )
+      whenever(dlqSqs.getQueueUrl(any<GetQueueUrlRequest>())).thenReturn(
+        CompletableFuture.completedFuture(GetQueueUrlResponse.builder().queueUrl("dlqUrl").build())
+      )
+
+      hmppsAsyncQueueService = HmppsAsyncQueueService(telemetryClient, hmppsAsyncTopicFactory, hmppsAsyncQueueFactory, hmppsSqsProperties)
+    }
+
+    @BeforeEach
+    fun `gets a message on the dlq`() {
+      whenever(dlqSqs.receiveMessage(any<ReceiveMessageRequest>()))
+        .thenReturn(
+          CompletableFuture.completedFuture(
+            ReceiveMessageResponse.builder().messages(
+              Message.builder().body(
+                """{
+                      "Message":{
+                        "id":"event-id",
+                        "contents":"event-contents",
+                        "longProperty":12345678
+                      },
+                      "MessageId":"message-id-1"
+                    }"""
+              )
+                .receiptHandle("message-1-receipt-handle").messageId("external-message-id-1").build()
+            ).build()
+          )
+        )
+
+      hmppsAsyncQueueService = HmppsAsyncQueueService(telemetryClient, hmppsAsyncTopicFactory, hmppsAsyncQueueFactory, hmppsSqsProperties)
+    }
+
+    @Test
+    fun `should handle zero messages on the dlq`() = runBlocking {
+      whenever(dlqSqs.getQueueAttributes(any<GetQueueAttributesRequest>())).thenReturn(
+        CompletableFuture.completedFuture(
+          GetQueueAttributesResponse.builder().attributes(mapOf(QueueAttributeName.APPROXIMATE_NUMBER_OF_MESSAGES to "0")).build()
+        )
+      )
+
+      val dlqResult = hmppsAsyncQueueService.getDlqMessages(
+        GetAsyncDlqRequest(HmppsAsyncQueue("some queue id", queueSqs, "some queue name", dlqSqs, "some dlq name"), 10)
+      )
+      assertThat(dlqResult.messagesFoundCount).isEqualTo(0)
+      assertThat(dlqResult.messagesReturnedCount).isEqualTo(0)
+      assertThat(dlqResult.messages).isEmpty()
+    }
+
+    @Test
+    fun `should get messages from the dlq`() = runBlocking<Unit> {
+      whenever(dlqSqs.getQueueAttributes(any<GetQueueAttributesRequest>())).thenReturn(
+        CompletableFuture.completedFuture(
+          GetQueueAttributesResponse.builder().attributes(mapOf(QueueAttributeName.APPROXIMATE_NUMBER_OF_MESSAGES to "1")).build()
+        )
+      )
+
+      val dlqResult = hmppsAsyncQueueService.getDlqMessages(
+        GetAsyncDlqRequest(HmppsAsyncQueue("some queue id", queueSqs, "some queue name", dlqSqs, "some dlq name"), 10)
+      )
+
+      assertThat(dlqResult.messagesFoundCount).isEqualTo(1)
+      assertThat(dlqResult.messagesReturnedCount).isEqualTo(1)
+      assertThat(dlqResult.messages[0].messageId).isEqualTo("external-message-id-1")
+      assertThat(dlqResult.messages[0].body["MessageId"]).isEqualTo("message-id-1")
+      verify(dlqSqs).receiveMessage(
+        check<ReceiveMessageRequest> {
+          assertThat(it.queueUrl()).isEqualTo("dlqUrl")
+        }
+      )
+    }
+
+    @Test
+    fun `should get multiple messages from the dlq`() = runBlocking<Unit> {
+      whenever(dlqSqs.getQueueAttributes(any<GetQueueAttributesRequest>())).thenReturn(
+        CompletableFuture.completedFuture(
+          GetQueueAttributesResponse.builder().attributes(mapOf(QueueAttributeName.APPROXIMATE_NUMBER_OF_MESSAGES to "3")).build()
+        )
+      )
+
+      val dlqResult = hmppsAsyncQueueService.getDlqMessages(
+        GetAsyncDlqRequest(HmppsAsyncQueue("some queue id", queueSqs, "some queue name", dlqSqs, "some dlq name"), 10)
+      )
+
+      assertThat(dlqResult.messagesFoundCount).isEqualTo(3)
+      assertThat(dlqResult.messagesReturnedCount).isEqualTo(3)
+      assertThat(dlqResult.messages[2].messageId).isEqualTo("external-message-id-1")
+      assertThat(dlqResult.messages[2].body["MessageId"]).isEqualTo("message-id-1")
+      verify(dlqSqs, times(3)).receiveMessage(
+        check<ReceiveMessageRequest> {
+          assertThat(it.queueUrl()).isEqualTo("dlqUrl")
+        }
+      )
+    }
+  }
+
+  @Nested
+  inner class FindQueueToPurge {
+
+    private val sqsClient = mock<SqsAsyncClient>()
+    private val sqsDlqClient = mock<SqsAsyncClient>()
+
+    @BeforeEach
+    fun `add test data`() {
+      whenever(sqsClient.getQueueUrl(any<GetQueueUrlRequest>()))
+        .thenReturn(CompletableFuture.completedFuture(GetQueueUrlResponse.builder().queueUrl("some queue url").build()))
+      whenever(sqsDlqClient.getQueueUrl(any<GetQueueUrlRequest>()))
+        .thenReturn(CompletableFuture.completedFuture(GetQueueUrlResponse.builder().queueUrl("some dlq url").build()))
+      whenever(hmppsAsyncQueueFactory.createHmppsAsyncQueues(any(), any()))
+        .thenReturn(
+          listOf(
+            HmppsAsyncQueue("some queue id", sqsClient, "some queue name", sqsDlqClient, "some dlq name"),
+            HmppsAsyncQueue("another queue id", mock(), "another queue name", mock(), "another dlq name"),
+          )
+        )
+
+      hmppsAsyncQueueService = HmppsAsyncQueueService(telemetryClient, hmppsAsyncTopicFactory, hmppsAsyncQueueFactory, hmppsSqsProperties)
+    }
+
+    @Test
+    fun `should find the main queue`() {
+      val request = hmppsAsyncQueueService.findQueueToPurge("some queue name")
+
+      assertThat(request?.queueName).isEqualTo("some queue name")
+    }
+
+    @Test
+    fun `should find the dlq`() {
+      val request = hmppsAsyncQueueService.findQueueToPurge("some dlq name")
+
+      assertThat(request?.queueName).isEqualTo("some dlq name")
+    }
+
+    @Test
+    fun `should return null if not queue or dlq`() {
+      val request = hmppsAsyncQueueService.findQueueToPurge("unknown queue name")
+
+      assertThat(request).isNull()
+    }
+  }
+
+  @Nested
+  inner class PurgeQueue {
+
+    private val sqsClient = mock<SqsAsyncClient>()
+    private val hmppsQueueService =
+      HmppsAsyncQueueService(telemetryClient, hmppsAsyncTopicFactory, hmppsAsyncQueueFactory, hmppsSqsProperties)
+
+    @Test
+    fun `no messages found, should not attempt to purge queue`() = runBlocking<Unit> {
+      stubMessagesOnQueue(0)
+
+      hmppsQueueService.purgeQueue(PurgeAsyncQueueRequest("some queue", sqsClient, "some queue url"))
+
+      verify(sqsClient, times(0)).purgeQueue(any<software.amazon.awssdk.services.sqs.model.PurgeQueueRequest>())
+    }
+
+    @Test
+    fun `no messages found, should not create telemetry event`() = runBlocking<Unit> {
+      stubMessagesOnQueue(0)
+
+      hmppsQueueService.purgeQueue(PurgeAsyncQueueRequest("some queue", sqsClient, "some queue url"))
+
+      verifyNoMoreInteractions(telemetryClient)
+    }
+
+    @Test
+    fun `messages found, should attempt to purge queue`() = runBlocking<Unit> {
+      stubMessagesOnQueue(1)
+
+      hmppsQueueService.purgeQueue(PurgeAsyncQueueRequest("some queue", sqsClient, "some queue url"))
+
+      verify(sqsClient).purgeQueue(software.amazon.awssdk.services.sqs.model.PurgeQueueRequest.builder().queueUrl("some queue url").build())
+    }
+
+    @Test
+    fun `messages found, should create telemetry event`() = runBlocking<Unit> {
+      stubMessagesOnQueue(1)
+
+      hmppsQueueService.purgeQueue(PurgeAsyncQueueRequest("some queue", sqsClient, "some queue url"))
+
+      verify(telemetryClient).trackEvent(
+        eq("PurgeQueue"),
+        check {
+          assertThat(it).containsEntry("queue-name", "some queue")
+          assertThat(it).containsEntry("messages-found", "1")
+        },
+        isNull()
+      )
+    }
+
+    @Test
+    fun `should return number of messages found to purge`() = runBlocking<Unit> {
+      stubMessagesOnQueue(5)
+
+      val result = hmppsQueueService.purgeQueue(PurgeAsyncQueueRequest("some queue", sqsClient, "some queue url"))
+
+      assertThat(result.messagesFoundCount).isEqualTo(5)
+    }
+
+    private fun stubMessagesOnQueue(messageCount: Int) {
+      whenever(sqsClient.getQueueUrl(any<GetQueueUrlRequest>()))
+        .thenReturn(CompletableFuture.completedFuture(GetQueueUrlResponse.builder().queueUrl("some queue url").build()))
+      whenever(sqsClient.getQueueAttributes(any<GetQueueAttributesRequest>()))
+        .thenReturn(
+          CompletableFuture.completedFuture(GetQueueAttributesResponse.builder().attributes(mapOf(QueueAttributeName.APPROXIMATE_NUMBER_OF_MESSAGES to "$messageCount")).build())
+        )
+    }
+  }
+}
+
+private fun stringAttributeOf(value: String?): MessageAttributeValue? {
+  return MessageAttributeValue.builder()
+    .dataType("String")
+    .stringValue(value)
+    .build()
+}


### PR DESCRIPTION
* make the asyncrhonous queue service non-blocking and add unit tests for it
* stop returning AWS messages from the retry DLQ endpoints and instead return the body as a map (in the same way as is done for the get DLQ endpoint). This prevents the previous horrible workaround of returning a Message.Builder to get around serialization issues.

Coming soon:
* make the asynchronous SQS clients work with the health endpoint correctly
* make the old syncrhonous endpoints work with asyncrhonous SQS clients
* add tests to the async-test-app to use the non-blocking endpoints