### PR TITLE
SDI-318 handle async clients

### DIFF
--- a/hmpps-sqs-spring-boot-autoconfigure/src/main/kotlin/uk/gov/justice/hmpps/sqs/HmppsAsyncQueueHealth.kt
+++ b/hmpps-sqs-spring-boot-autoconfigure/src/main/kotlin/uk/gov/justice/hmpps/sqs/HmppsAsyncQueueHealth.kt
@@ -89,13 +89,13 @@ class HmppsAsyncQueueHealth(private val hmppsQueue: HmppsAsyncQueue) : HealthInd
 
   private fun getQueueAttributes(): Result<GetQueueAttributesResponse> {
     return runCatching {
-      hmppsQueue.sqsAsyncClient.getQueueAttributes(GetQueueAttributesRequest.builder().queueUrl(hmppsQueue.queueUrl).build()).get()
+      hmppsQueue.sqsAsyncClient.getQueueAttributes(GetQueueAttributesRequest.builder().queueUrl(hmppsQueue.queueUrl).attributeNames(QueueAttributeName.ALL).build()).get()
     }
   }
 
   private fun getDlqAttributes(): Result<GetQueueAttributesResponse> =
     runCatching {
-      hmppsQueue.sqsAsyncClient.getQueueAttributes(GetQueueAttributesRequest.builder().queueUrl(hmppsQueue.queueUrl).build())?.get()
+      hmppsQueue.sqsAsyncClient.getQueueAttributes(GetQueueAttributesRequest.builder().queueUrl(hmppsQueue.queueUrl).attributeNames(QueueAttributeName.ALL).build())?.get()
         ?: throw MissingDlqClientException(hmppsQueue.dlqName)
     }
 }

--- a/hmpps-sqs-spring-boot-autoconfigure/src/main/kotlin/uk/gov/justice/hmpps/sqs/HmppsSqsConfiguration.kt
+++ b/hmpps-sqs-spring-boot-autoconfigure/src/main/kotlin/uk/gov/justice/hmpps/sqs/HmppsSqsConfiguration.kt
@@ -55,7 +55,7 @@ class HmppsSqsConfiguration {
   @Bean
   @ConditionalOnMissingBean
   @ConditionalOnExpression("'\${hmpps.sqs.reactiveApi:false}'.equals('false')")
-  fun hmppsQueueResource(hmppsQueueService: HmppsQueueService) = HmppsQueueResource(hmppsQueueService)
+  fun hmppsQueueResource(hmppsQueueService: HmppsQueueService, hmppsAsyncQueueService: HmppsAsyncQueueService) = HmppsQueueResource(hmppsQueueService, hmppsAsyncQueueService)
 
   @Bean
   @ConditionalOnMissingBean

--- a/hmpps-sqs-spring-boot-autoconfigure/src/main/kotlin/uk/gov/justice/hmpps/sqs/HmppsSqsConfiguration.kt
+++ b/hmpps-sqs-spring-boot-autoconfigure/src/main/kotlin/uk/gov/justice/hmpps/sqs/HmppsSqsConfiguration.kt
@@ -1,10 +1,10 @@
 package uk.gov.justice.hmpps.sqs
 
 import com.microsoft.applicationinsights.TelemetryClient
-import org.springframework.boot.actuate.autoconfigure.health.HealthEndpointAutoConfiguration
 import org.springframework.boot.autoconfigure.AutoConfigureBefore
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.boot.autoconfigure.web.reactive.WebFluxAutoConfiguration
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.ConfigurableApplicationContext
 import org.springframework.context.annotation.Bean
@@ -15,7 +15,7 @@ import org.springframework.jms.annotation.EnableJms
 @Configuration
 @EnableConfigurationProperties(HmppsSqsProperties::class)
 @EnableJms
-@AutoConfigureBefore(HealthEndpointAutoConfiguration::class)
+@AutoConfigureBefore(WebFluxAutoConfiguration::class)
 class HmppsSqsConfiguration {
 
   @Bean

--- a/hmpps-sqs-spring-boot-autoconfigure/src/test/kotlin/uk/gov/justice/hmpps/sqs/HmppsAsyncQueueResourceTest.kt
+++ b/hmpps-sqs-spring-boot-autoconfigure/src/test/kotlin/uk/gov/justice/hmpps/sqs/HmppsAsyncQueueResourceTest.kt
@@ -99,6 +99,7 @@ class HmppsAsyncQueueResourceTest {
   inner class RetryAllDlqs {
     @Test
     fun `should call the service`() = runBlocking<Unit> {
+      whenever(hmppsQueueService.retryAllDlqs()).thenReturn(listOf())
       whenever(hmppsAsyncQueueService.retryAllDlqs()).thenReturn(listOf())
 
       webTestClient.put()
@@ -106,6 +107,7 @@ class HmppsAsyncQueueResourceTest {
         .exchange()
         .expectStatus().isOk
 
+      verify(hmppsQueueService).retryAllDlqs()
       verify(hmppsAsyncQueueService).retryAllDlqs()
     }
   }

--- a/hmpps-sqs-spring-boot-autoconfigure/src/test/kotlin/uk/gov/justice/hmpps/sqs/HmppsQueueResourceTest.kt
+++ b/hmpps-sqs-spring-boot-autoconfigure/src/test/kotlin/uk/gov/justice/hmpps/sqs/HmppsQueueResourceTest.kt
@@ -1,12 +1,17 @@
 package uk.gov.justice.hmpps.sqs
 
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.ArgumentMatchers.anyString
 import org.mockito.kotlin.any
 import org.mockito.kotlin.check
+import org.mockito.kotlin.doSuspendableAnswer
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -31,10 +36,13 @@ class HmppsQueueResourceTest {
   @MockBean
   private lateinit var hmppsQueueService: HmppsQueueService
 
+  @MockBean
+  private lateinit var hmppsAsyncQueueService: HmppsAsyncQueueService
+
   @Nested
   inner class RetryDlq {
     @Test
-    fun `should call the service`() {
+    fun `should call the service for a sync queue client`() {
       val hmppsQueue = mock<HmppsQueue>()
       whenever(hmppsQueueService.findByDlqName("some dlq name"))
         .thenReturn(hmppsQueue)
@@ -52,6 +60,28 @@ class HmppsQueueResourceTest {
     }
 
     @Test
+    fun `should call the service for an async queue client`() = runBlocking<Unit> {
+      val hmppsAsyncQueue = mock<HmppsAsyncQueue>()
+      whenever(hmppsQueueService.findByDlqName("some dlq name"))
+        .thenReturn(null)
+      whenever(hmppsAsyncQueueService.findByDlqName("some dlq name"))
+        .thenReturn(hmppsAsyncQueue)
+      whenever(hmppsAsyncQueueService.retryDlqMessages(any())).doSuspendableAnswer {
+        withContext(Dispatchers.Default) { RetryDlqResult(2, listOf(DlqMessage(mapOf("key" to "value"), "id"))) }
+      }
+
+      mockMvc.perform(put("/queue-admin/retry-dlq/some dlq name"))
+        .andExpect(status().isOk)
+        .andExpect(jsonPath("$.messagesFoundCount").value(2))
+        .andExpect(jsonPath("$.messages.length()").value(1))
+        .andExpect(jsonPath("$.messages[0].messageId").value("id"))
+        .andExpect(jsonPath("$.messages[0].body.key").value("value"))
+
+      verify(hmppsQueueService, never()).retryDlqMessages(any())
+      verify(hmppsAsyncQueueService).retryDlqMessages(RetryAsyncDlqRequest(hmppsAsyncQueue))
+    }
+
+    @Test
     fun `should return not found`() {
       whenever(hmppsQueueService.findByDlqName("some dlq name")).thenReturn(null)
 
@@ -65,20 +95,22 @@ class HmppsQueueResourceTest {
   @Nested
   inner class RetryAllDlqs {
     @Test
-    fun `should call the service`() {
+    fun `should call the service`() = runBlocking<Unit> {
       whenever(hmppsQueueService.retryAllDlqs()).thenReturn(listOf())
+      whenever(hmppsAsyncQueueService.retryAllDlqs()).thenReturn(listOf())
 
       mockMvc.perform(put("/queue-admin/retry-all-dlqs"))
         .andExpect(status().isOk)
 
       verify(hmppsQueueService).retryAllDlqs()
+      verify(hmppsAsyncQueueService).retryAllDlqs()
     }
   }
 
   @Nested
   inner class PurgeQueue {
     @Test
-    fun `should attempt to purge queue if found`() {
+    fun `should attempt to purge with sync queue client`() {
       whenever(hmppsQueueService.findQueueToPurge("some queue"))
         .thenReturn(PurgeQueueRequest("some queue", mock(), "some queue url"))
       whenever(hmppsQueueService.purgeQueue(any()))
@@ -89,7 +121,31 @@ class HmppsQueueResourceTest {
         .andExpect(jsonPath("$.messagesFoundCount").value(10))
 
       verify(hmppsQueueService).findQueueToPurge("some queue")
+      verify(hmppsAsyncQueueService, never()).findQueueToPurge("some queue")
       verify(hmppsQueueService).purgeQueue(
+        check {
+          assertThat(it.queueName).isEqualTo("some queue")
+        }
+      )
+    }
+
+    @Test
+    fun `should attempt to purge with async queue client`() = runBlocking<Unit> {
+      whenever(hmppsQueueService.findQueueToPurge("some queue"))
+        .thenReturn(null)
+      whenever(hmppsAsyncQueueService.findQueueToPurge("some queue"))
+        .thenReturn(PurgeAsyncQueueRequest("some queue", mock(), "some queue url"))
+      whenever(hmppsAsyncQueueService.purgeQueue(any())).doSuspendableAnswer {
+        withContext(Dispatchers.Default) { PurgeQueueResult(10) }
+      }
+
+      mockMvc.perform(put("/queue-admin/purge-queue/some queue"))
+        .andExpect(status().isOk)
+        .andExpect(jsonPath("$.messagesFoundCount").value(10))
+
+      verify(hmppsQueueService).findQueueToPurge("some queue")
+      verify(hmppsAsyncQueueService).findQueueToPurge("some queue")
+      verify(hmppsAsyncQueueService).purgeQueue(
         check {
           assertThat(it.queueName).isEqualTo("some queue")
         }

--- a/test-app-async/README.md
+++ b/test-app-async/README.md
@@ -6,11 +6,11 @@ This project should be kept up to date with the template project to keep it as c
 
 ## Running the test-app locally
 
-Start localstack with command:
+Start localstack with command from the project root directory:
 
 `docker-compose -f docker-compose-test.yml up`
 
-The run the app in Intellij from class `HmppsTemplateKotlin` with Spring active profile `stdout`.
+The run the app in Intellij from class `ReactiveApp` with Spring active profiles `stdout,localstack`.
 
 You should now be able to see the health page at `http://localhost:8080/health`.
 

--- a/test-app-async/src/main/resources/application-localstack.yml
+++ b/test-app-async/src/main/resources/application-localstack.yml
@@ -11,6 +11,11 @@ hmpps.sqs:
       dlqName: async-outbound-dlq
       subscribeTopicId: outboundtopic
       subscribeFilter: '{"eventType":[ "offender.movement.reception"] }'
+    asyncqueue:
+      dlqName: async-async-dlq
+      queueName: async-async-queue
+      asyncDlqClient: true
+      asyncQueueClient: true
   topics:
     inboundtopic:
       arn: arn:aws:sns:eu-west-2:000000000000:async-inbound-topic

--- a/test-app-async/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppstemplatepackagenameasync/integration/HmppsQueueResourceTest_asyncClient.kt
+++ b/test-app-async/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppstemplatepackagenameasync/integration/HmppsQueueResourceTest_asyncClient.kt
@@ -1,0 +1,120 @@
+package uk.gov.justice.digital.hmpps.hmppstemplatepackagenameasync.integration
+
+import org.awaitility.kotlin.await
+import org.awaitility.kotlin.matches
+import org.awaitility.kotlin.untilCallTo
+import org.hamcrest.Matchers
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.verify
+import org.springframework.http.MediaType
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest
+import uk.gov.justice.digital.hmpps.hmppstemplatepackagenameasync.service.EventType
+import uk.gov.justice.digital.hmpps.hmppstemplatepackagenameasync.service.HmppsEvent
+import uk.gov.justice.digital.hmpps.hmppstemplatepackagenameasync.service.Message
+import uk.gov.justice.digital.hmpps.hmppstemplatepackagenameasync.service.MessageAttributes
+
+class HmppsQueueResourceTest_asyncClient : IntegrationTestBase() {
+
+  @Nested
+  inner class RetryDlq {
+    @Test
+    fun `should transfer messages from the async DLQ to the async queue`() {
+      val event1 = HmppsEvent("id1", "test.type", "message3")
+      val event2 = HmppsEvent("id2", "test.type", "message4")
+      val message1 = Message(gsonString(event1), "message-id1", MessageAttributes(EventType("test.type", "String")))
+      val message2 = Message(gsonString(event2), "message-id2", MessageAttributes(EventType("test.type", "String")))
+      asyncSqsDlqClient.sendMessage(SendMessageRequest.builder().queueUrl(asyncDlqUrl).messageBody(gsonString(message1)).build())
+      asyncSqsDlqClient.sendMessage(SendMessageRequest.builder().queueUrl(asyncDlqUrl).messageBody(gsonString(message2)).build())
+      await untilCallTo { asyncSqsDlqClient.countMessagesOnQueue(asyncDlqUrl) } matches { it == 2 }
+
+      webTestClient.put()
+        .uri("/queue-admin/retry-dlq/${hmppsSqsPropertiesSpy.asyncQueueConfig().dlqName}")
+        .headers { it.authToken() }
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus().isOk
+
+      await untilCallTo { asyncSqsDlqClient.countMessagesOnQueue(asyncDlqUrl) } matches { it == 0 }
+      await untilCallTo { asyncSqsClient.countMessagesOnQueue(asyncQueueUrl) } matches { it == 2 }
+    }
+  }
+
+  @Nested
+  inner class RetryAllDlqs {
+    @Test
+    fun `should transfer messages from async as well as normal queues`() {
+      val event5 = HmppsEvent("id5", "test.type", "message5")
+      val event6 = HmppsEvent("id6", "test.type", "message6")
+      val message5 = Message(gsonString(event5), "message-id5", MessageAttributes(EventType("test.type", "String")))
+      val message6 = Message(gsonString(event6), "message-id6", MessageAttributes(EventType("test.type", "String")))
+      asyncSqsDlqClient.sendMessage(SendMessageRequest.builder().queueUrl(asyncDlqUrl).messageBody(gsonString(message5)).build())
+      inboundSqsDlqClient.sendMessage(SendMessageRequest.builder().queueUrl(inboundDlqUrl).messageBody(gsonString(message6)).build())
+      await untilCallTo { asyncSqsDlqClient.countMessagesOnQueue(asyncDlqUrl) } matches { it == 1 }
+      await untilCallTo { inboundSqsDlqClient.countMessagesOnQueue(inboundDlqUrl) } matches { it == 1 }
+
+      webTestClient.put()
+        .uri("/queue-admin/retry-all-dlqs")
+        .headers { it.authToken() }
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus().isOk
+
+      await untilCallTo { asyncSqsDlqClient.countMessagesOnQueue(asyncDlqUrl) } matches { it == 0 }
+      await untilCallTo { asyncSqsClient.countMessagesOnQueue(asyncQueueUrl) } matches { it == 1 }
+
+      await untilCallTo { inboundSqsDlqClient.countMessagesOnQueue(inboundDlqUrl) } matches { it == 0 }
+      await untilCallTo { inboundSqsClient.countMessagesOnQueue(inboundQueueUrl) } matches { it == 0 }
+      verify(inboundMessageServiceSpy).handleMessage(event6)
+    }
+  }
+
+  @Nested
+  inner class PurgeQueue {
+    @Test
+    fun `should purge the async dlq`() {
+      asyncSqsDlqClient.sendMessage(SendMessageRequest.builder().queueUrl(asyncDlqUrl).messageBody(gsonString(HmppsEvent("id1", "test.type", "message1"))).build())
+      asyncSqsDlqClient.sendMessage(SendMessageRequest.builder().queueUrl(asyncDlqUrl).messageBody(gsonString(HmppsEvent("id2", "test.type", "message2"))).build())
+      await untilCallTo { asyncSqsDlqClient.countMessagesOnQueue(asyncDlqUrl) } matches { it == 2 }
+
+      webTestClient.put()
+        .uri("/queue-admin/purge-queue/${hmppsSqsPropertiesSpy.asyncQueueConfig().dlqName}")
+        .headers { it.authToken() }
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus().isOk
+
+      await untilCallTo { asyncSqsDlqClient.countMessagesOnQueue(asyncDlqUrl) } matches { it == 0 }
+    }
+  }
+
+  @Nested
+  inner class GetDlqMessages {
+    val defaultMessageAttributes = MessageAttributes(EventType("test.type", "String"))
+    val defaultEvent = HmppsEvent("event-id", "test.type", "event-contents")
+    fun testMessage(id: String) = Message(gsonString(defaultEvent), "message-$id", defaultMessageAttributes)
+    @Test
+    fun `should get all messages from the async dlq`() {
+      for (i in 1..3) {
+        asyncSqsDlqClient.sendMessage(SendMessageRequest.builder().queueUrl(asyncDlqUrl).messageBody(gsonString(testMessage("id-$i"))).build())
+      }
+      await untilCallTo { asyncSqsDlqClient.countMessagesOnQueue(asyncDlqUrl) } matches { it == 3 }
+
+      webTestClient.get()
+        .uri("/queue-admin/get-dlq-messages/${hmppsSqsPropertiesSpy.asyncQueueConfig().dlqName}")
+        .headers { it.authToken() }
+        .exchange()
+        .expectStatus().isOk
+        .expectBody()
+        .jsonPath("messagesFoundCount").isEqualTo(3)
+        .jsonPath("messagesReturnedCount").isEqualTo(3)
+        .jsonPath("messages..body.MessageId").value(
+          Matchers.containsInAnyOrder(
+            "message-id-1",
+            "message-id-2",
+            "message-id-3"
+          )
+        )
+    }
+  }
+}

--- a/test-app-async/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppstemplatepackagenameasync/integration/IntegrationTestBase.kt
+++ b/test-app-async/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppstemplatepackagenameasync/integration/IntegrationTestBase.kt
@@ -49,8 +49,8 @@ abstract class IntegrationTestBase {
     outboundSqsDlqClientSpy.purgeQueue(PurgeQueueRequest.builder().queueUrl(outboundDlqUrl).build())
     outboundTestSqsClient.purgeQueue(PurgeQueueRequest.builder().queueUrl(outboundTestQueueUrl).build())
     outboundTestNoDlqSqsClient.purgeQueue(PurgeQueueRequest.builder().queueUrl(outboundTestNoDlqQueueUrl).build())
-    asyncSqsClient.purgeQueue(PurgeQueueRequest.builder().queueUrl(asyncQueueUrl).build())
-    asyncSqsDlqClient.purgeQueue(PurgeQueueRequest.builder().queueUrl(asyncDlqUrl).build())
+    asyncSqsClient.purgeQueue(PurgeQueueRequest.builder().queueUrl(asyncQueueUrl).build()).get()
+    asyncSqsDlqClient.purgeQueue(PurgeQueueRequest.builder().queueUrl(asyncDlqUrl).build()).get()
   }
 
   fun HmppsSqsProperties.inboundQueueConfig() =

--- a/test-app-async/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppstemplatepackagenameasync/integration/health/QueueHealthCheckTest.kt
+++ b/test-app-async/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppstemplatepackagenameasync/integration/health/QueueHealthCheckTest.kt
@@ -45,4 +45,24 @@ class QueueHealthCheckTest : IntegrationTestBase() {
       .jsonPath("components.outboundqueue-health.details.dlqStatus").isEqualTo("UP")
       .jsonPath("components.outboundqueue-health.details.messagesOnDlq").isEqualTo(0)
   }
+
+  @Test
+  fun `Async queue health ok`() {
+    oAuthApi.stubHealthPing(200)
+
+    webTestClient.get()
+      .uri("/health")
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectBody()
+      .jsonPath("status").isEqualTo("UP")
+      .jsonPath("components.asyncqueue-health.status").isEqualTo("UP")
+      .jsonPath("components.asyncqueue-health.details.queueName").isEqualTo(hmppsSqsPropertiesSpy.asyncQueueConfig().queueName)
+      .jsonPath("components.asyncqueue-health.details.messagesOnQueue").isEqualTo(0)
+      .jsonPath("components.asyncqueue-health.details.messagesInFlight").isEqualTo(0)
+      .jsonPath("components.asyncqueue-health.details.dlqName").isEqualTo(hmppsSqsPropertiesSpy.asyncQueueConfig().dlqName)
+      .jsonPath("components.asyncqueue-health.details.dlqStatus").isEqualTo("UP")
+      .jsonPath("components.asyncqueue-health.details.messagesOnDlq").isEqualTo(0)
+  }
 }

--- a/test-app-async/src/test/resources/application-test.yml
+++ b/test-app-async/src/test/resources/application-test.yml
@@ -32,6 +32,11 @@ hmpps.sqs:
       queueName: ${random.uuid}
       subscribeTopicId: outboundtopic
       subscribeFilter: '{"eventType":[ "offender.movement.reception"] }'
+    asyncqueue:
+      dlqName: ${random.uuid}
+      queueName: ${random.uuid}
+      asyncDlqClient: true
+      asyncQueueClient: true
   topics:
     inboundtopic:
       arn: arn:aws:sns:eu-west-2:000000000000:${random.uuid}

--- a/test-app/README.md
+++ b/test-app/README.md
@@ -6,11 +6,11 @@ This project should be kept up to date with the template project to keep it as c
 
 ## Running the test-app locally
 
-Start localstack with command:
+Start localstack with command from the project root directory:
 
 `docker-compose -f docker-compose-test.yml up`
 
-The run the app in Intellij from class `HmppsTemplateKotlin` with Spring active profile `stdout`.
+The run the app in Intellij from class `App` with Spring active profiles `stdout,localstack`.
 
 You should now be able to see the health page at `http://localhost:8080/health`.
 

--- a/test-app/src/main/resources/application-localstack.yml
+++ b/test-app/src/main/resources/application-localstack.yml
@@ -11,6 +11,11 @@ hmpps.sqs:
       dlqName: outbound-dlq
       subscribeTopicId: outboundtopic
       subscribeFilter: '{"eventType":[ "offender.movement.reception"] }'
+    asyncqueue:
+      dlqName: async-dlq
+      queueName: async-queue
+      asyncDlqClient: true
+      asyncQueueClient: true
   topics:
     inboundtopic:
       arn: arn:aws:sns:eu-west-2:000000000000:inbound-topic

--- a/test-app/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppstemplatepackagename/integration/HmppsQueueResourceTest_asyncClient.kt
+++ b/test-app/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppstemplatepackagename/integration/HmppsQueueResourceTest_asyncClient.kt
@@ -1,0 +1,120 @@
+package uk.gov.justice.digital.hmpps.hmppstemplatepackagename.integration
+
+import org.awaitility.kotlin.await
+import org.awaitility.kotlin.matches
+import org.awaitility.kotlin.untilCallTo
+import org.hamcrest.Matchers
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.verify
+import org.springframework.http.MediaType
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest
+import uk.gov.justice.digital.hmpps.hmppstemplatepackagename.service.EventType
+import uk.gov.justice.digital.hmpps.hmppstemplatepackagename.service.HmppsEvent
+import uk.gov.justice.digital.hmpps.hmppstemplatepackagename.service.Message
+import uk.gov.justice.digital.hmpps.hmppstemplatepackagename.service.MessageAttributes
+
+class HmppsQueueResourceTest_asyncClient : IntegrationTestBase() {
+
+  @Nested
+  inner class RetryDlq {
+    @Test
+    fun `should transfer messages from the async DLQ to the async queue`() {
+      val event1 = HmppsEvent("id1", "test.type", "message3")
+      val event2 = HmppsEvent("id2", "test.type", "message4")
+      val message1 = Message(gsonString(event1), "message-id1", MessageAttributes(EventType("test.type", "String")))
+      val message2 = Message(gsonString(event2), "message-id2", MessageAttributes(EventType("test.type", "String")))
+      asyncSqsDlqClient.sendMessage(SendMessageRequest.builder().queueUrl(asyncDlqUrl).messageBody(gsonString(message1)).build())
+      asyncSqsDlqClient.sendMessage(SendMessageRequest.builder().queueUrl(asyncDlqUrl).messageBody(gsonString(message2)).build())
+      await untilCallTo { asyncSqsDlqClient.countMessagesOnQueue(asyncDlqUrl) } matches { it == 2 }
+
+      webTestClient.put()
+        .uri("/queue-admin/retry-dlq/${hmppsSqsPropertiesSpy.asyncQueueConfig().dlqName}")
+        .headers { it.authToken() }
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus().isOk
+
+      await untilCallTo { asyncSqsDlqClient.countMessagesOnQueue(asyncDlqUrl) } matches { it == 0 }
+      await untilCallTo { asyncSqsClient.countMessagesOnQueue(asyncQueueUrl) } matches { it == 2 }
+    }
+  }
+
+  @Nested
+  inner class RetryAllDlqs {
+    @Test
+    fun `should transfer messages from async as well as normal queues`() {
+      val event5 = HmppsEvent("id5", "test.type", "message5")
+      val event6 = HmppsEvent("id6", "test.type", "message6")
+      val message5 = Message(gsonString(event5), "message-id5", MessageAttributes(EventType("test.type", "String")))
+      val message6 = Message(gsonString(event6), "message-id6", MessageAttributes(EventType("test.type", "String")))
+      asyncSqsDlqClient.sendMessage(SendMessageRequest.builder().queueUrl(asyncDlqUrl).messageBody(gsonString(message5)).build())
+      inboundSqsDlqClient.sendMessage(SendMessageRequest.builder().queueUrl(inboundDlqUrl).messageBody(gsonString(message6)).build())
+      await untilCallTo { asyncSqsDlqClient.countMessagesOnQueue(asyncDlqUrl) } matches { it == 1 }
+      await untilCallTo { inboundSqsDlqClient.countMessagesOnQueue(inboundDlqUrl) } matches { it == 1 }
+
+      webTestClient.put()
+        .uri("/queue-admin/retry-all-dlqs")
+        .headers { it.authToken() }
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus().isOk
+
+      await untilCallTo { asyncSqsDlqClient.countMessagesOnQueue(asyncDlqUrl) } matches { it == 0 }
+      await untilCallTo { asyncSqsClient.countMessagesOnQueue(asyncQueueUrl) } matches { it == 1 }
+
+      await untilCallTo { inboundSqsDlqClient.countMessagesOnQueue(inboundDlqUrl) } matches { it == 0 }
+      await untilCallTo { inboundSqsClient.countMessagesOnQueue(inboundQueueUrl) } matches { it == 0 }
+      verify(inboundMessageServiceSpy).handleMessage(event6)
+    }
+  }
+
+  @Nested
+  inner class PurgeQueue {
+    @Test
+    fun `should purge the async dlq`() {
+      asyncSqsDlqClient.sendMessage(SendMessageRequest.builder().queueUrl(asyncDlqUrl).messageBody(gsonString(HmppsEvent("id1", "test.type", "message1"))).build())
+      asyncSqsDlqClient.sendMessage(SendMessageRequest.builder().queueUrl(asyncDlqUrl).messageBody(gsonString(HmppsEvent("id2", "test.type", "message2"))).build())
+      await untilCallTo { asyncSqsDlqClient.countMessagesOnQueue(asyncDlqUrl) } matches { it == 2 }
+
+      webTestClient.put()
+        .uri("/queue-admin/purge-queue/${hmppsSqsPropertiesSpy.asyncQueueConfig().dlqName}")
+        .headers { it.authToken() }
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus().isOk
+
+      await untilCallTo { asyncSqsDlqClient.countMessagesOnQueue(asyncDlqUrl) } matches { it == 0 }
+    }
+  }
+
+  @Nested
+  inner class GetDlqMessages {
+    val defaultMessageAttributes = MessageAttributes(EventType("test.type", "String"))
+    val defaultEvent = HmppsEvent("event-id", "test.type", "event-contents")
+    fun testMessage(id: String) = Message(gsonString(defaultEvent), "message-$id", defaultMessageAttributes)
+    @Test
+    fun `should get all messages from the async dlq`() {
+      for (i in 1..3) {
+        asyncSqsDlqClient.sendMessage(SendMessageRequest.builder().queueUrl(asyncDlqUrl).messageBody(gsonString(testMessage("id-$i"))).build())
+      }
+      await untilCallTo { asyncSqsDlqClient.countMessagesOnQueue(asyncDlqUrl) } matches { it == 3 }
+
+      webTestClient.get()
+        .uri("/queue-admin/get-dlq-messages/${hmppsSqsPropertiesSpy.asyncQueueConfig().dlqName}")
+        .headers { it.authToken() }
+        .exchange()
+        .expectStatus().isOk
+        .expectBody()
+        .jsonPath("messagesFoundCount").isEqualTo(3)
+        .jsonPath("messagesReturnedCount").isEqualTo(3)
+        .jsonPath("messages..body.MessageId").value(
+          Matchers.contains(
+            "message-id-1",
+            "message-id-2",
+            "message-id-3"
+          )
+        )
+    }
+  }
+}

--- a/test-app/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppstemplatepackagename/integration/HmppsQueueResourceTest_asyncClient.kt
+++ b/test-app/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppstemplatepackagename/integration/HmppsQueueResourceTest_asyncClient.kt
@@ -109,7 +109,7 @@ class HmppsQueueResourceTest_asyncClient : IntegrationTestBase() {
         .jsonPath("messagesFoundCount").isEqualTo(3)
         .jsonPath("messagesReturnedCount").isEqualTo(3)
         .jsonPath("messages..body.MessageId").value(
-          Matchers.contains(
+          Matchers.containsInAnyOrder(
             "message-id-1",
             "message-id-2",
             "message-id-3"

--- a/test-app/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppstemplatepackagename/integration/IntegrationTestBase.kt
+++ b/test-app/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppstemplatepackagename/integration/IntegrationTestBase.kt
@@ -17,6 +17,7 @@ import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.DynamicPropertyRegistry
 import org.springframework.test.context.DynamicPropertySource
 import org.springframework.test.web.reactive.server.WebTestClient
+import software.amazon.awssdk.services.sqs.SqsAsyncClient
 import software.amazon.awssdk.services.sqs.SqsClient
 import software.amazon.awssdk.services.sqs.model.GetQueueAttributesRequest
 import software.amazon.awssdk.services.sqs.model.PurgeQueueRequest
@@ -27,6 +28,7 @@ import uk.gov.justice.digital.hmpps.hmppstemplatepackagename.integration.testcon
 import uk.gov.justice.digital.hmpps.hmppstemplatepackagename.service.InboundMessageService
 import uk.gov.justice.digital.hmpps.hmppstemplatepackagename.service.OutboundEventsEmitter
 import uk.gov.justice.digital.hmpps.hmppstemplatepackagename.service.OutboundMessageService
+import uk.gov.justice.hmpps.sqs.HmppsAsyncQueueService
 import uk.gov.justice.hmpps.sqs.HmppsQueueFactory
 import uk.gov.justice.hmpps.sqs.HmppsQueueService
 import uk.gov.justice.hmpps.sqs.HmppsSqsProperties
@@ -47,6 +49,8 @@ abstract class IntegrationTestBase {
     outboundSqsDlqClientSpy.purgeQueue(PurgeQueueRequest.builder().queueUrl(outboundDlqUrl).build())
     outboundTestSqsClient.purgeQueue(PurgeQueueRequest.builder().queueUrl(outboundTestQueueUrl).build())
     outboundTestNoDlqSqsClient.purgeQueue(PurgeQueueRequest.builder().queueUrl(outboundTestNoDlqQueueUrl).build())
+    asyncSqsClient.purgeQueue(PurgeQueueRequest.builder().queueUrl(asyncQueueUrl).build())
+    asyncSqsDlqClient.purgeQueue(PurgeQueueRequest.builder().queueUrl(asyncDlqUrl).build())
   }
 
   fun HmppsSqsProperties.inboundQueueConfig() =
@@ -54,6 +58,9 @@ abstract class IntegrationTestBase {
 
   fun HmppsSqsProperties.outboundQueueConfig() =
     queues["outboundqueue"] ?: throw MissingQueueException("outboundqueue has not been loaded from configuration properties")
+
+  fun HmppsSqsProperties.asyncQueueConfig() =
+    queues["asyncqueue"] ?: throw MissingQueueException("asyncqueue has not been loaded from configuration properties")
 
   fun HmppsSqsProperties.inboundTopicConfig() =
     topics["inboundtopic"] ?: throw MissingTopicException("inboundtopic has not been loaded from configuration properties")
@@ -66,12 +73,15 @@ abstract class IntegrationTestBase {
   private val outboundTestQueue by lazy { hmppsQueueService.findByQueueId("outboundtestqueue") ?: throw MissingQueueException("HmppsQueue outboundtestqueue not found") }
   private val inboundTopic by lazy { hmppsQueueService.findByTopicId("inboundtopic") ?: throw MissingQueueException("HmppsTopic inboundtopic not found") }
   private val outboundTestNoDlqQueue by lazy { hmppsQueueService.findByQueueId("outboundtestnodlqqueue") ?: throw MissingQueueException("HmppsQueue outboundtestnodlqqueue not found") }
+  private val asyncQueue by lazy { hmppsAsyncQueueService.findByQueueId("asyncqueue") ?: throw MissingQueueException("HmppsQueue asyncqueue not found") }
 
   protected val inboundSqsClient by lazy { inboundQueue.sqsClient }
   protected val inboundSqsDlqClient by lazy { inboundQueue.sqsDlqClient as SqsClient }
   protected val inboundSnsClient by lazy { inboundTopic.snsClient }
   protected val outboundTestSqsClient by lazy { outboundTestQueue.sqsClient }
   protected val outboundTestNoDlqSqsClient by lazy { outboundTestNoDlqQueue.sqsClient }
+  protected val asyncSqsClient by lazy { asyncQueue.sqsAsyncClient }
+  protected val asyncSqsDlqClient by lazy { asyncQueue.sqsAsyncDlqClient as SqsAsyncClient }
 
   @SpyBean
   @Qualifier("outboundqueue-sqs-client")
@@ -87,6 +97,8 @@ abstract class IntegrationTestBase {
   protected val outboundDlqUrl by lazy { outboundQueue.dlqUrl as String }
   protected val outboundTestQueueUrl by lazy { outboundTestQueue.queueUrl }
   protected val outboundTestNoDlqQueueUrl by lazy { outboundTestNoDlqQueue.queueUrl }
+  protected val asyncQueueUrl by lazy { asyncQueue.queueUrl }
+  protected val asyncDlqUrl by lazy { asyncQueue.dlqUrl as String }
 
   protected val inboundTopicArn by lazy { inboundTopic.arn }
 
@@ -98,6 +110,9 @@ abstract class IntegrationTestBase {
 
   @Autowired
   protected lateinit var hmppsQueueService: HmppsQueueService
+
+  @Autowired
+  protected lateinit var hmppsAsyncQueueService: HmppsAsyncQueueService
 
   @SpyBean
   protected lateinit var inboundMessageServiceSpy: InboundMessageService
@@ -117,6 +132,10 @@ abstract class IntegrationTestBase {
   internal fun SqsClient.countMessagesOnQueue(queueUrl: String): Int =
     this.getQueueAttributes(GetQueueAttributesRequest.builder().queueUrl(queueUrl).attributeNames(QueueAttributeName.APPROXIMATE_NUMBER_OF_MESSAGES).build())
       .let { it.attributes()[QueueAttributeName.APPROXIMATE_NUMBER_OF_MESSAGES]?.toInt() ?: 0 }
+
+  internal fun SqsAsyncClient.countMessagesOnQueue(queueUrl: String): Int =
+    this.getQueueAttributes(GetQueueAttributesRequest.builder().queueUrl(queueUrl).attributeNames(QueueAttributeName.APPROXIMATE_NUMBER_OF_MESSAGES).build())
+      .let { it.get().attributes()[QueueAttributeName.APPROXIMATE_NUMBER_OF_MESSAGES]?.toInt() ?: 0 }
 
   internal fun HttpHeaders.authToken(roles: List<String> = listOf("ROLE_QUEUE_ADMIN")) {
     this.setBearerAuth(

--- a/test-app/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppstemplatepackagename/integration/IntegrationTestBase.kt
+++ b/test-app/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppstemplatepackagename/integration/IntegrationTestBase.kt
@@ -49,8 +49,8 @@ abstract class IntegrationTestBase {
     outboundSqsDlqClientSpy.purgeQueue(PurgeQueueRequest.builder().queueUrl(outboundDlqUrl).build())
     outboundTestSqsClient.purgeQueue(PurgeQueueRequest.builder().queueUrl(outboundTestQueueUrl).build())
     outboundTestNoDlqSqsClient.purgeQueue(PurgeQueueRequest.builder().queueUrl(outboundTestNoDlqQueueUrl).build())
-    asyncSqsClient.purgeQueue(PurgeQueueRequest.builder().queueUrl(asyncQueueUrl).build())
-    asyncSqsDlqClient.purgeQueue(PurgeQueueRequest.builder().queueUrl(asyncDlqUrl).build())
+    asyncSqsClient.purgeQueue(PurgeQueueRequest.builder().queueUrl(asyncQueueUrl).build()).get()
+    asyncSqsDlqClient.purgeQueue(PurgeQueueRequest.builder().queueUrl(asyncDlqUrl).build()).get()
   }
 
   fun HmppsSqsProperties.inboundQueueConfig() =

--- a/test-app/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppstemplatepackagename/integration/health/QueueHealthCheckTest.kt
+++ b/test-app/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppstemplatepackagename/integration/health/QueueHealthCheckTest.kt
@@ -45,4 +45,24 @@ class QueueHealthCheckTest : IntegrationTestBase() {
       .jsonPath("components.outboundqueue-health.details.dlqStatus").isEqualTo("UP")
       .jsonPath("components.outboundqueue-health.details.messagesOnDlq").isEqualTo(0)
   }
+
+  @Test
+  fun `Async queue health ok`() {
+    oAuthApi.stubHealthPing(200)
+
+    webTestClient.get()
+      .uri("/health")
+      .exchange()
+      .expectStatus()
+      .isOk
+      .expectBody()
+      .jsonPath("status").isEqualTo("UP")
+      .jsonPath("components.asyncqueue-health.status").isEqualTo("UP")
+      .jsonPath("components.asyncqueue-health.details.queueName").isEqualTo(hmppsSqsPropertiesSpy.asyncQueueConfig().queueName)
+      .jsonPath("components.asyncqueue-health.details.messagesOnQueue").isEqualTo(0)
+      .jsonPath("components.asyncqueue-health.details.messagesInFlight").isEqualTo(0)
+      .jsonPath("components.asyncqueue-health.details.dlqName").isEqualTo(hmppsSqsPropertiesSpy.asyncQueueConfig().dlqName)
+      .jsonPath("components.asyncqueue-health.details.dlqStatus").isEqualTo("UP")
+      .jsonPath("components.asyncqueue-health.details.messagesOnDlq").isEqualTo(0)
+  }
 }

--- a/test-app/src/test/resources/application-test.yml
+++ b/test-app/src/test/resources/application-test.yml
@@ -31,6 +31,11 @@ hmpps.sqs:
       queueName: ${random.uuid}
       subscribeTopicId: outboundtopic
       subscribeFilter: '{"eventType":[ "offender.movement.reception"] }'
+    asyncqueue:
+      dlqName: ${random.uuid}
+      queueName: ${random.uuid}
+      asyncDlqClient: true
+      asyncQueueClient: true
   topics:
     inboundtopic:
       arn: arn:aws:sns:eu-west-2:000000000000:${random.uuid}


### PR DESCRIPTION
Handle async clients on the non-reactive API and add async client integration tests for both APIs.