### PR TITLE
PI-803 - update to use queue arn for moving to SB3

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 
 allprojects {
   group = "uk.gov.justice.service.hmpps"
-  version = "2.0.0-beta-10"
+  version = "2.0.0-beta-11"
 
   repositories {
     maven { url = uri("https://repo.spring.io/milestone") }

--- a/hmpps-sqs-spring-boot-autoconfigure/src/test/kotlin/uk/gov/justice/hmpps/sqs/HmppsQueueFactoryTest.kt
+++ b/hmpps-sqs-spring-boot-autoconfigure/src/test/kotlin/uk/gov/justice/hmpps/sqs/HmppsQueueFactoryTest.kt
@@ -53,8 +53,12 @@ class HmppsQueueFactoryTest {
       whenever(sqsDlqClient.getQueueUrl(GetQueueUrlRequest.builder().queueName("some dlq name").build()))
         .thenReturn(CompletableFuture.completedFuture(GetQueueUrlResponse.builder().queueUrl("some dlq url").build()))
       whenever(sqsClient.getQueueAttributes(any<GetQueueAttributesRequest>()))
-        .thenReturn(CompletableFuture.completedFuture(GetQueueAttributesResponse.builder()
-          .attributes(mutableMapOf(QueueAttributeName.QUEUE_ARN to "queue:arn")).build()))
+        .thenReturn(
+          CompletableFuture.completedFuture(
+            GetQueueAttributesResponse.builder()
+              .attributes(mutableMapOf(QueueAttributeName.QUEUE_ARN to "queue:arn")).build()
+          )
+        )
 
       hmppsQueues = hmppsQueueFactory.createHmppsQueues(hmppsSqsProperties)
     }
@@ -103,8 +107,12 @@ class HmppsQueueFactoryTest {
       whenever(sqsClient.getQueueUrl(any<GetQueueUrlRequest>()))
         .thenReturn(CompletableFuture.completedFuture(GetQueueUrlResponse.builder().queueUrl("some queue url").build()))
       whenever(sqsClient.getQueueAttributes(any<GetQueueAttributesRequest>()))
-        .thenReturn(CompletableFuture.completedFuture(GetQueueAttributesResponse.builder()
-          .attributes(mutableMapOf(QueueAttributeName.QUEUE_ARN to "queue:arn")).build()))
+        .thenReturn(
+          CompletableFuture.completedFuture(
+            GetQueueAttributesResponse.builder()
+              .attributes(mutableMapOf(QueueAttributeName.QUEUE_ARN to "queue:arn")).build()
+          )
+        )
       whenever(sqsDlqClient.getQueueUrl(any<GetQueueUrlRequest>()))
         .thenReturn(CompletableFuture.completedFuture(GetQueueUrlResponse.builder().queueUrl("some dlq url").build()))
       whenever(sqsDlqClient.getQueueAttributes(any<GetQueueAttributesRequest>()))

--- a/hmpps-sqs-spring-boot-autoconfigure/src/test/kotlin/uk/gov/justice/hmpps/sqs/HmppsQueueFactoryTest.kt
+++ b/hmpps-sqs-spring-boot-autoconfigure/src/test/kotlin/uk/gov/justice/hmpps/sqs/HmppsQueueFactoryTest.kt
@@ -52,6 +52,9 @@ class HmppsQueueFactoryTest {
         .thenReturn(CompletableFuture.completedFuture(GetQueueUrlResponse.builder().queueUrl("some queue url").build()))
       whenever(sqsDlqClient.getQueueUrl(GetQueueUrlRequest.builder().queueName("some dlq name").build()))
         .thenReturn(CompletableFuture.completedFuture(GetQueueUrlResponse.builder().queueUrl("some dlq url").build()))
+      whenever(sqsClient.getQueueAttributes(any<GetQueueAttributesRequest>()))
+        .thenReturn(CompletableFuture.completedFuture(GetQueueAttributesResponse.builder()
+          .attributes(mutableMapOf(QueueAttributeName.QUEUE_ARN to "queue:arn")).build()))
 
       hmppsQueues = hmppsQueueFactory.createHmppsQueues(hmppsSqsProperties)
     }
@@ -99,6 +102,9 @@ class HmppsQueueFactoryTest {
         .thenReturn(sqsClient)
       whenever(sqsClient.getQueueUrl(any<GetQueueUrlRequest>()))
         .thenReturn(CompletableFuture.completedFuture(GetQueueUrlResponse.builder().queueUrl("some queue url").build()))
+      whenever(sqsClient.getQueueAttributes(any<GetQueueAttributesRequest>()))
+        .thenReturn(CompletableFuture.completedFuture(GetQueueAttributesResponse.builder()
+          .attributes(mutableMapOf(QueueAttributeName.QUEUE_ARN to "queue:arn")).build()))
       whenever(sqsDlqClient.getQueueUrl(any<GetQueueUrlRequest>()))
         .thenReturn(CompletableFuture.completedFuture(GetQueueUrlResponse.builder().queueUrl("some dlq url").build()))
       whenever(sqsDlqClient.getQueueAttributes(any<GetQueueAttributesRequest>()))

--- a/hmpps-sqs-spring-boot-autoconfigure/src/test/kotlin/uk/gov/justice/hmpps/sqs/HmppsQueueFactoryTest_NoDlq.kt
+++ b/hmpps-sqs-spring-boot-autoconfigure/src/test/kotlin/uk/gov/justice/hmpps/sqs/HmppsQueueFactoryTest_NoDlq.kt
@@ -24,6 +24,8 @@ import software.amazon.awssdk.services.sns.model.SubscribeRequest
 import software.amazon.awssdk.services.sqs.SqsAsyncClient
 import software.amazon.awssdk.services.sqs.model.CreateQueueRequest
 import software.amazon.awssdk.services.sqs.model.CreateQueueResponse
+import software.amazon.awssdk.services.sqs.model.GetQueueAttributesRequest
+import software.amazon.awssdk.services.sqs.model.GetQueueAttributesResponse
 import software.amazon.awssdk.services.sqs.model.GetQueueUrlRequest
 import software.amazon.awssdk.services.sqs.model.GetQueueUrlResponse
 import software.amazon.awssdk.services.sqs.model.QueueAttributeName
@@ -58,6 +60,10 @@ class HmppsQueueFactoryTest_NoDlq {
       whenever(sqsClient.getQueueUrl(any<GetQueueUrlRequest>())).thenReturn(
         CompletableFuture.completedFuture(GetQueueUrlResponse.builder().queueUrl("some queue url").build())
       )
+      whenever(sqsClient.getQueueAttributes(any<GetQueueAttributesRequest>()))
+        .thenReturn(CompletableFuture.completedFuture(
+          GetQueueAttributesResponse.builder()
+          .attributes(mutableMapOf(QueueAttributeName.QUEUE_ARN to "queue:arn")).build()))
 
       hmppsQueues = hmppsQueueFactory.createHmppsQueues(hmppsSqsProperties)
     }
@@ -137,6 +143,9 @@ class HmppsQueueFactoryTest_NoDlq {
       whenever(sqsClient.getQueueUrl(any<GetQueueUrlRequest>())).thenReturn(
         CompletableFuture.completedFuture(GetQueueUrlResponse.builder().queueUrl("some queue url").build())
       )
+      whenever(sqsClient.getQueueAttributes(any<GetQueueAttributesRequest>()))
+        .thenReturn(CompletableFuture.completedFuture(GetQueueAttributesResponse.builder()
+          .attributes(mutableMapOf(QueueAttributeName.QUEUE_ARN to "queue:arn")).build()))
 
       hmppsQueues = hmppsQueueFactory.createHmppsQueues(hmppsSqsProperties)
     }
@@ -219,6 +228,9 @@ class HmppsQueueFactoryTest_NoDlq {
         .thenReturn(CompletableFuture.completedFuture(GetQueueUrlResponse.builder().queueUrl("some queue url").build()))
       whenever(sqsClient.getQueueUrl(GetQueueUrlRequest.builder().queueName("another queue name").build()))
         .thenReturn(CompletableFuture.completedFuture(GetQueueUrlResponse.builder().queueUrl("another queue url").build()))
+      whenever(sqsClient.getQueueAttributes(any<GetQueueAttributesRequest>()))
+        .thenReturn(CompletableFuture.completedFuture(GetQueueAttributesResponse.builder()
+          .attributes(mutableMapOf(QueueAttributeName.QUEUE_ARN to "queue:arn")).build()))
 
       hmppsQueues = hmppsQueueFactory.createHmppsQueues(hmppsSqsProperties)
     }
@@ -263,6 +275,9 @@ class HmppsQueueFactoryTest_NoDlq {
       whenever(sqsClient.getQueueUrl(any<GetQueueUrlRequest>())).thenReturn(
         CompletableFuture.completedFuture(GetQueueUrlResponse.builder().queueUrl("some queue url").build())
       )
+      whenever(sqsClient.getQueueAttributes(any<GetQueueAttributesRequest>()))
+        .thenReturn(CompletableFuture.completedFuture(GetQueueAttributesResponse.builder()
+          .attributes(mutableMapOf(QueueAttributeName.QUEUE_ARN to "queue:arn")).build()))
 
       hmppsQueues = hmppsQueueFactory.createHmppsQueues(hmppsSqsProperties, topics)
     }
@@ -278,7 +293,7 @@ class HmppsQueueFactoryTest_NoDlq {
         check<SubscribeRequest> { subscribeRequest ->
           assertThat(subscribeRequest.topicArn()).isEqualTo("some topic arn")
           assertThat(subscribeRequest.protocol()).isEqualTo("sqs")
-          assertThat(subscribeRequest.endpoint()).isEqualTo("http://localhost:4566/queue/some-queue-name")
+          assertThat(subscribeRequest.endpoint()).isEqualTo("queue:arn")
           assertThat(subscribeRequest.attributes()["FilterPolicy"]).isEqualTo("some topic filter")
         }
       )
@@ -302,6 +317,9 @@ class HmppsQueueFactoryTest_NoDlq {
       whenever(sqsClient.getQueueUrl(any<GetQueueUrlRequest>())).thenReturn(
         CompletableFuture.completedFuture(GetQueueUrlResponse.builder().queueUrl("some queue url").build())
       )
+      whenever(sqsClient.getQueueAttributes(any<GetQueueAttributesRequest>()))
+        .thenReturn(CompletableFuture.completedFuture(GetQueueAttributesResponse.builder()
+          .attributes(mutableMapOf(QueueAttributeName.QUEUE_ARN to "queue:arn")).build()))
 
       hmppsQueues = hmppsQueueFactory.createHmppsQueues(hmppsSqsProperties, topics)
     }

--- a/hmpps-sqs-spring-boot-autoconfigure/src/test/kotlin/uk/gov/justice/hmpps/sqs/HmppsQueueFactoryTest_NoDlq.kt
+++ b/hmpps-sqs-spring-boot-autoconfigure/src/test/kotlin/uk/gov/justice/hmpps/sqs/HmppsQueueFactoryTest_NoDlq.kt
@@ -61,9 +61,12 @@ class HmppsQueueFactoryTest_NoDlq {
         CompletableFuture.completedFuture(GetQueueUrlResponse.builder().queueUrl("some queue url").build())
       )
       whenever(sqsClient.getQueueAttributes(any<GetQueueAttributesRequest>()))
-        .thenReturn(CompletableFuture.completedFuture(
-          GetQueueAttributesResponse.builder()
-          .attributes(mutableMapOf(QueueAttributeName.QUEUE_ARN to "queue:arn")).build()))
+        .thenReturn(
+          CompletableFuture.completedFuture(
+            GetQueueAttributesResponse.builder()
+              .attributes(mutableMapOf(QueueAttributeName.QUEUE_ARN to "queue:arn")).build()
+          )
+        )
 
       hmppsQueues = hmppsQueueFactory.createHmppsQueues(hmppsSqsProperties)
     }
@@ -144,8 +147,12 @@ class HmppsQueueFactoryTest_NoDlq {
         CompletableFuture.completedFuture(GetQueueUrlResponse.builder().queueUrl("some queue url").build())
       )
       whenever(sqsClient.getQueueAttributes(any<GetQueueAttributesRequest>()))
-        .thenReturn(CompletableFuture.completedFuture(GetQueueAttributesResponse.builder()
-          .attributes(mutableMapOf(QueueAttributeName.QUEUE_ARN to "queue:arn")).build()))
+        .thenReturn(
+          CompletableFuture.completedFuture(
+            GetQueueAttributesResponse.builder()
+              .attributes(mutableMapOf(QueueAttributeName.QUEUE_ARN to "queue:arn")).build()
+          )
+        )
 
       hmppsQueues = hmppsQueueFactory.createHmppsQueues(hmppsSqsProperties)
     }
@@ -229,8 +236,12 @@ class HmppsQueueFactoryTest_NoDlq {
       whenever(sqsClient.getQueueUrl(GetQueueUrlRequest.builder().queueName("another queue name").build()))
         .thenReturn(CompletableFuture.completedFuture(GetQueueUrlResponse.builder().queueUrl("another queue url").build()))
       whenever(sqsClient.getQueueAttributes(any<GetQueueAttributesRequest>()))
-        .thenReturn(CompletableFuture.completedFuture(GetQueueAttributesResponse.builder()
-          .attributes(mutableMapOf(QueueAttributeName.QUEUE_ARN to "queue:arn")).build()))
+        .thenReturn(
+          CompletableFuture.completedFuture(
+            GetQueueAttributesResponse.builder()
+              .attributes(mutableMapOf(QueueAttributeName.QUEUE_ARN to "queue:arn")).build()
+          )
+        )
 
       hmppsQueues = hmppsQueueFactory.createHmppsQueues(hmppsSqsProperties)
     }
@@ -276,8 +287,12 @@ class HmppsQueueFactoryTest_NoDlq {
         CompletableFuture.completedFuture(GetQueueUrlResponse.builder().queueUrl("some queue url").build())
       )
       whenever(sqsClient.getQueueAttributes(any<GetQueueAttributesRequest>()))
-        .thenReturn(CompletableFuture.completedFuture(GetQueueAttributesResponse.builder()
-          .attributes(mutableMapOf(QueueAttributeName.QUEUE_ARN to "queue:arn")).build()))
+        .thenReturn(
+          CompletableFuture.completedFuture(
+            GetQueueAttributesResponse.builder()
+              .attributes(mutableMapOf(QueueAttributeName.QUEUE_ARN to "queue:arn")).build()
+          )
+        )
 
       hmppsQueues = hmppsQueueFactory.createHmppsQueues(hmppsSqsProperties, topics)
     }
@@ -318,8 +333,12 @@ class HmppsQueueFactoryTest_NoDlq {
         CompletableFuture.completedFuture(GetQueueUrlResponse.builder().queueUrl("some queue url").build())
       )
       whenever(sqsClient.getQueueAttributes(any<GetQueueAttributesRequest>()))
-        .thenReturn(CompletableFuture.completedFuture(GetQueueAttributesResponse.builder()
-          .attributes(mutableMapOf(QueueAttributeName.QUEUE_ARN to "queue:arn")).build()))
+        .thenReturn(
+          CompletableFuture.completedFuture(
+            GetQueueAttributesResponse.builder()
+              .attributes(mutableMapOf(QueueAttributeName.QUEUE_ARN to "queue:arn")).build()
+          )
+        )
 
       hmppsQueues = hmppsQueueFactory.createHmppsQueues(hmppsSqsProperties, topics)
     }

--- a/release-notes/2.0.0.md
+++ b/release-notes/2.0.0.md
@@ -2,4 +2,6 @@
 
 This release targets Spring Boot 3.
 
-We have also switched to [io.awspring.cloud](https://github.com/awspring/spring-cloud-aws) as the old java messaging library wasn't compatible with JMS 2.0.
+We have also switched to [io.awspring.cloud](https://github.com/awspring/spring-cloud-aws) as the old java messaging library wasn't compatible with JMS 2.0. 
+
+Updated the subscription to use Queue ARN rather than url - resolves and issue with invalid SQS ARN when subscribing with a protocol of `sqs`


### PR DESCRIPTION
The existing implementation seems to be failing when using queue url. Updating to queue arn seems to fix the issue and then works on later versions of localstack too.