### PR TITLE
Topic subscription unit tests

### DIFF
--- a/hmpps-sqs-spring-boot-autoconfigure/src/test/kotlin/uk/gov/justice/hmpps/sqs/HmppsQueueFactoryTest.kt
+++ b/hmpps-sqs-spring-boot-autoconfigure/src/test/kotlin/uk/gov/justice/hmpps/sqs/HmppsQueueFactoryTest.kt
@@ -178,9 +178,11 @@ class HmppsQueueFactoryTest {
 
       hmppsQueues = hmppsQueueFactory.createHmppsQueues(hmppsSqsProperties, topics)
 
-      verify(snsClient).subscribe(check<SubscribeRequest> {
-        assertThat(it.topicArn()).isEqualTo("arn:aws:sns:1:2:3")
-      })
+      verify(snsClient).subscribe(
+        check<SubscribeRequest> {
+          assertThat(it.topicArn()).isEqualTo("arn:aws:sns:1:2:3")
+        }
+      )
     }
   }
 }


### PR DESCRIPTION
The [topic subscription tests](https://github.com/ministryofjustice/hmpps-spring-boot-sqs/blob/main/hmpps-sqs-spring-boot-autoconfigure/src/test/kotlin/uk/gov/justice/hmpps/sqs/HmppsQueueFactoryTest.kt#L424) got lost during the mammoth task of migrating to AWS SDK V2