### PR TITLE
Clarify property naming conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,12 @@ Examples of property usage can be found in the test project in the following pla
 
 #### HmppsSqsProperties Definitions
 
+##### :warning: queueId and topicId Must Be All Lowercase And Alpha
+
+As we define the production queue and topic properties in environment variables that map to a complex object in `HmppsSqsProperties` Spring is unable to handle a mixed case `queueId` or `topicId` and struggles with hyphens and underscores. Therefore please make the `queueId` and `topicId` a single word that is all lower case (or upper case when defining env vars in the Helm values files).
+
+E.g. I know you'd like to use property `hmpps.sqs.queues.my-service-queue.queueName`, but your life will be much easier if you name the property `hmpps.sqs.queues.myservicequeue.queueName`.
+
 | Property      | Default                 | Description                                                                                                                                                                                                                             |
 |---------------|-------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | provider      | `aws`                   | `aws` for production or `localstack` for running locally / integration tests.                                                                                                                                                           |
@@ -100,7 +106,7 @@ Each queue declared in the `queues` map is defined in the `QueueConfig` property
 
 | Property               | Default | Description                                                                                                                                                                                                                                                                                                                                |
 |------------------------|---------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| queueId                |         | The key to the `queues` map. A unique name for the queue configuration, used heavily when automatically creating Spring beans. Must be lower case.                                                                                                                                                                                         |
+| queueId                |         | The key to the `queues` map. A unique name for the queue configuration, used heavily when automatically creating Spring beans. Must be lower case letters only (no hyphens or underscores).                                                                                                                                                |
 | queueName              |         | The name of the queue as recognised by AWS or LocalStack. The AWS queue name, should be derived from an environment variable of format `HMPPS_SQS_QUEUES_<queueId>_QUEUE_NAME`.                                                                                                                                                            |
 | queueAccessKeyId       |         | Only used for `provider=aws`. The AWS access key ID, should be derived from an environment variable of format `HMPPS_SQS_QUEUES_<queueId>_QUEUE_ACCESS_KEY_ID`.                                                                                                                                                                            |
 | queueSecretAccessKey   |         | Only used for `provider=aws`. The AWS secret access key, should be derived from an environment variable of format `HMPPS_SQS_QUEUES_<queueId>_QUEUE_SECRET_ACCESS_KEY`.                                                                                                                                                                    |
@@ -115,16 +121,12 @@ Each queue declared in the `queues` map is defined in the `QueueConfig` property
 
 Each topic declared in the `topics` map is defined in the `TopicConfig` property class
 
-| Property        | Default | Description                                                                                                                                                       |
-|-----------------|---------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| topicId         |         | The key to the `topics` map. A unique name for the topic configuration, used heavily when automatically creating Spring beans. Must be lower case.                |
-| arn             |         | The ARN of the topic as recognised by AWS and LocalStack.                                                                                                         |
-| accessKeyId     |         | Only used for `provider=aws`. The AWS access key ID, should be derived from an environment variable of format `HMPPS_SQS_TOPICS_<topicId>_ACCESS_KEY_ID`.         | 
-| secretAccessKey |         | Only used for `provider=aws`. The AWS secret access key, should be derived from an environment variable of format `HMPPS_SQS_TOPICS_<topicId>_SECRET_ACCESS_KEY`. |
-
-#### :warning: queueId and topicId Must Be All Lowercase
-
-As we define the production queue and topic properties in environment variables that map to a complex object in `HmppsSqsProperties` Spring is unable to handle a mixed case `queueId` or `topicId`.
+| Property        | Default | Description                                                                                                                                                                                 |
+|-----------------|---------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| topicId         |         | The key to the `topics` map. A unique name for the topic configuration, used heavily when automatically creating Spring beans. Must be lower case letters only (no hyphens or underscores). |
+| arn             |         | The ARN of the topic as recognised by AWS and LocalStack.                                                                                                                                   |
+| accessKeyId     |         | Only used for `provider=aws`. The AWS access key ID, should be derived from an environment variable of format `HMPPS_SQS_TOPICS_<topicId>_ACCESS_KEY_ID`.                                   | 
+| secretAccessKey |         | Only used for `provider=aws`. The AWS secret access key, should be derived from an environment variable of format `HMPPS_SQS_TOPICS_<topicId>_SECRET_ACCESS_KEY`.                           |
 
 ### SqsListener
 


### PR DESCRIPTION
(cherry picked from commit 9c86b20854505cda4d323fe35722294d3200c456)