### PR TITLE
SDIT-864 Improve RetryDLQ in SQS lib (sb3)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 
 allprojects {
   group = "uk.gov.justice.service.hmpps"
-  version = "3.1.3"
+  version = "3.2-beta"
 
   repositories {
     mavenCentral()

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   localstack:
     image: localstack/localstack:3

--- a/hmpps-sqs-spring-boot-autoconfigure/build.gradle.kts
+++ b/hmpps-sqs-spring-boot-autoconfigure/build.gradle.kts
@@ -17,8 +17,8 @@ plugins {
 
 dependencyManagement {
   imports {
-    mavenBom("software.amazon.awssdk:bom:2.20.157")
-    mavenBom("io.awspring.cloud:spring-cloud-aws-dependencies:3.0.2")
+    mavenBom("software.amazon.awssdk:bom:2.25.34")
+    mavenBom("io.awspring.cloud:spring-cloud-aws-dependencies:3.1.1")
   }
 }
 

--- a/hmpps-sqs-spring-boot-autoconfigure/src/test/kotlin/uk/gov/justice/hmpps/sqs/HmppsQueueResourceTest.kt
+++ b/hmpps-sqs-spring-boot-autoconfigure/src/test/kotlin/uk/gov/justice/hmpps/sqs/HmppsQueueResourceTest.kt
@@ -39,7 +39,7 @@ class HmppsQueueResourceTest {
       whenever(hmppsQueueService.findByDlqName("some dlq name"))
         .thenReturn(hmppsAsyncQueue)
       whenever(hmppsQueueService.retryDlqMessages(any())).doSuspendableAnswer {
-        withContext(Dispatchers.Default) { RetryDlqResult(2, listOf(DlqMessage(mapOf("key" to "value"), "id"))) }
+        withContext(Dispatchers.Default) { RetryDlqResult(2) }
       }
 
       webTestClient.put()
@@ -48,9 +48,6 @@ class HmppsQueueResourceTest {
         .expectStatus().isOk
         .expectBody()
         .jsonPath("$.messagesFoundCount").isEqualTo(2)
-        .jsonPath("$.messages.length()").isEqualTo(1)
-        .jsonPath("$.messages[0].messageId").isEqualTo("id")
-        .jsonPath("$.messages[0].body.key").isEqualTo("value")
 
       verify(hmppsQueueService).retryDlqMessages(RetryDlqRequest(hmppsAsyncQueue))
     }

--- a/hmpps-sqs-spring-boot-autoconfigure/src/test/kotlin/uk/gov/justice/hmpps/sqs/HmppsReactiveQueueResourceTest.kt
+++ b/hmpps-sqs-spring-boot-autoconfigure/src/test/kotlin/uk/gov/justice/hmpps/sqs/HmppsReactiveQueueResourceTest.kt
@@ -42,7 +42,7 @@ class HmppsReactiveQueueResourceTest {
       whenever(hmppsQueueService.findByDlqName("some dlq name"))
         .thenReturn(hmppsAsyncQueue)
       whenever(hmppsQueueService.retryDlqMessages(any())).doSuspendableAnswer {
-        withContext(Dispatchers.Default) { RetryDlqResult(2, listOf(DlqMessage(mapOf("key" to "value"), "id"))) }
+        withContext(Dispatchers.Default) { RetryDlqResult(2) }
       }
 
       webTestClient.put()
@@ -51,9 +51,6 @@ class HmppsReactiveQueueResourceTest {
         .expectStatus().isOk
         .expectBody()
         .jsonPath("$.messagesFoundCount").isEqualTo(2)
-        .jsonPath("$.messages.length()").isEqualTo(1)
-        .jsonPath("$.messages[0].messageId").isEqualTo("id")
-        .jsonPath("$.messages[0].body.key").isEqualTo("value")
 
       verify(hmppsQueueService).retryDlqMessages(RetryDlqRequest(hmppsAsyncQueue))
     }

--- a/release-notes/3.x.md
+++ b/release-notes/3.x.md
@@ -1,3 +1,12 @@
+# 3.2
+This release modifies the DLQ retry logic to take advantage of a new AWS function which transfers messages to the main
+queue in one go rather than sending and receiving them individually. This should prove
+more robust when there are large numbers of messages involved (> 20000).
+
+## Breaking changes
+The retry endpoint, function and telemetry no longer reports the list of moved messages, only the message count initially found
+for the DLQ.
+
 # 3.1.1
 
 Remove code references to `reactiveApi` as it isn't used.  The library will automatically

--- a/test-app-reactive/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppstemplatepackagenameasync/integration/testcontainers/LocalStackContainer.kt
+++ b/test-app-reactive/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppstemplatepackagenameasync/integration/testcontainers/LocalStackContainer.kt
@@ -26,7 +26,7 @@ object LocalStackContainer {
     log.info("Creating a localstack instance")
     val logConsumer = Slf4jLogConsumer(log).withPrefix("localstack")
     return LocalStackContainer(
-      DockerImageName.parse("localstack/localstack").withTag("2.3"),
+      DockerImageName.parse("localstack/localstack").withTag("3"),
     ).apply {
       withServices(LocalStackContainer.Service.SNS, LocalStackContainer.Service.SQS)
       withEnv("DEFAULT_REGION", "eu-west-2")

--- a/test-app/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppstemplatepackagename/integration/HmppsQueueSpyBeanTest.kt
+++ b/test-app/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppstemplatepackagename/integration/HmppsQueueSpyBeanTest.kt
@@ -10,12 +10,11 @@ import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.springframework.http.MediaType
-import software.amazon.awssdk.services.sqs.model.DeleteMessageRequest
 import software.amazon.awssdk.services.sqs.model.GetQueueAttributesRequest
 import software.amazon.awssdk.services.sqs.model.MessageAttributeValue
 import software.amazon.awssdk.services.sqs.model.PurgeQueueRequest
-import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest
 import software.amazon.awssdk.services.sqs.model.SendMessageRequest
+import software.amazon.awssdk.services.sqs.model.StartMessageMoveTaskRequest
 import uk.gov.justice.digital.hmpps.hmppstemplatepackagename.service.EventType
 import uk.gov.justice.digital.hmpps.hmppstemplatepackagename.service.HmppsEvent
 import uk.gov.justice.digital.hmpps.hmppstemplatepackagename.service.Message
@@ -55,17 +54,14 @@ class HmppsQueueSpyBeanTest : IntegrationTestBase() {
     await untilCallTo { outboundSqsDlqClientSpy.countMessagesOnQueue(outboundDlqUrl).get() } matches { it == 0 }
     await untilCallTo { outboundSqsClientSpy.countMessagesOnQueue(outboundQueueUrl).get() } matches { it == 0 }
 
-    val captor = argumentCaptor<SendMessageRequest>()
-
     verify(outboundMessageServiceSpy).handleMessage(event)
-    verify(outboundSqsDlqClientSpy).receiveMessage(ReceiveMessageRequest.builder().queueUrl(outboundDlqUrl).maxNumberOfMessages(1).messageAttributeNames("All").build())
-    verify(outboundSqsDlqClientSpy).deleteMessage(any<DeleteMessageRequest>())
 
-    verify(outboundSqsClientSpy).sendMessage(captor.capture())
+    val captor = argumentCaptor<StartMessageMoveTaskRequest>()
+    verify(outboundSqsDlqClientSpy).startMessageMoveTask(captor.capture())
 
-    assertThat(captor.firstValue.queueUrl()).isEqualTo(outboundQueueUrl)
-    assertThat(captor.firstValue.messageBody()).isEqualTo(gsonString(message))
-    assertThat(captor.firstValue.messageAttributes()).isEqualTo(messageAttributes)
+    assertThat(captor.firstValue.sourceArn()).contains("000000000000")
+    assertThat(captor.firstValue.destinationArn()).contains("000000000000")
+    assertThat(captor.firstValue.maxNumberOfMessagesPerSecond()).isEqualTo(10)
   }
 
   @Test

--- a/test-app/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppstemplatepackagename/integration/testcontainers/LocalStackContainer.kt
+++ b/test-app/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppstemplatepackagename/integration/testcontainers/LocalStackContainer.kt
@@ -26,7 +26,7 @@ object LocalStackContainer {
     log.info("Creating a localstack instance")
     val logConsumer = Slf4jLogConsumer(log).withPrefix("localstack")
     return LocalStackContainer(
-      DockerImageName.parse("localstack/localstack").withTag("2.3"),
+      DockerImageName.parse("localstack/localstack").withTag("3"),
     ).apply {
       withServices(LocalStackContainer.Service.SNS, LocalStackContainer.Service.SQS)
       withEnv("DEFAULT_REGION", "eu-west-2")


### PR DESCRIPTION
Modifies the DLQ retry logic to take advantage of a new AWS function which transfers messages to the main queue in one go rather than sending and receiving them individually.