### PR TITLE
PI-2342 Enable trace propagation across SNS/SQS

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 
 allprojects {
   group = "uk.gov.justice.service.hmpps"
-  version = "4.0.1"
+  version = "4.1.0"
 
   repositories {
     mavenCentral()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 
 allprojects {
   group = "uk.gov.justice.service.hmpps"
-  version = "4.1.0"
+  version = "4.1.0-beta"
 
   repositories {
     mavenCentral()

--- a/hmpps-sqs-spring-boot-autoconfigure/build.gradle.kts
+++ b/hmpps-sqs-spring-boot-autoconfigure/build.gradle.kts
@@ -32,7 +32,7 @@ dependencies {
   implementation("io.awspring.cloud:spring-cloud-aws-sqs")
   implementation("com.google.code.gson:gson:2.11.0")
   implementation("com.microsoft.azure:applicationinsights-core:3.5.3")
-  implementation("io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations:2.5.0")
+  implementation("io.opentelemetry:opentelemetry-api")
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor")
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-jdk8")
 

--- a/hmpps-sqs-spring-boot-autoconfigure/build.gradle.kts
+++ b/hmpps-sqs-spring-boot-autoconfigure/build.gradle.kts
@@ -32,6 +32,7 @@ dependencies {
   implementation("io.awspring.cloud:spring-cloud-aws-sqs")
   implementation("com.google.code.gson:gson:2.11.0")
   implementation("com.microsoft.azure:applicationinsights-core:3.5.3")
+  implementation("io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations:2.5.0")
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor")
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-jdk8")
 

--- a/hmpps-sqs-spring-boot-autoconfigure/src/main/kotlin/uk/gov/justice/hmpps/sqs/HmppsSqsConfiguration.kt
+++ b/hmpps-sqs-spring-boot-autoconfigure/src/main/kotlin/uk/gov/justice/hmpps/sqs/HmppsSqsConfiguration.kt
@@ -78,8 +78,8 @@ class HmppsSqsConfiguration {
 
   @Bean
   @ConditionalOnMissingBean
-  fun hmppsQueueFactory(applicationContext: ConfigurableApplicationContext, healthContributorRegistry: HmppsHealthContributorRegistry) =
-    HmppsQueueFactory(applicationContext, healthContributorRegistry, SqsClientFactory())
+  fun hmppsQueueFactory(applicationContext: ConfigurableApplicationContext, healthContributorRegistry: HmppsHealthContributorRegistry, objectMapper: ObjectMapper) =
+    HmppsQueueFactory(applicationContext, healthContributorRegistry, SqsClientFactory(), objectMapper)
 
   @Bean
   @ConditionalOnMissingBean

--- a/hmpps-sqs-spring-boot-autoconfigure/src/main/kotlin/uk/gov/justice/hmpps/sqs/SnsClientFactory.kt
+++ b/hmpps-sqs-spring-boot-autoconfigure/src/main/kotlin/uk/gov/justice/hmpps/sqs/SnsClientFactory.kt
@@ -7,6 +7,7 @@ import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.sns.SnsAsyncClient
+import uk.gov.justice.hmpps.sqs.telemetry.TraceInjectingExecutionInterceptor
 import java.net.URI
 
 class SnsClientFactory {
@@ -23,6 +24,7 @@ class SnsClientFactory {
     return SnsAsyncClient.builder()
       .credentialsProvider(credentialsProvider)
       .region(Region.of(region))
+      .overrideConfiguration { it.addExecutionInterceptor(TraceInjectingExecutionInterceptor()) }
       .build()
   }
 
@@ -31,5 +33,6 @@ class SnsClientFactory {
       .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("any", "any")))
       .endpointOverride(URI.create(localstackUrl))
       .region(Region.of(region))
+      .overrideConfiguration { it.addExecutionInterceptor(TraceInjectingExecutionInterceptor()) }
       .build()
 }

--- a/hmpps-sqs-spring-boot-autoconfigure/src/main/kotlin/uk/gov/justice/hmpps/sqs/SqsClientFactory.kt
+++ b/hmpps-sqs-spring-boot-autoconfigure/src/main/kotlin/uk/gov/justice/hmpps/sqs/SqsClientFactory.kt
@@ -7,6 +7,7 @@ import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.sqs.SqsAsyncClient
+import uk.gov.justice.hmpps.sqs.telemetry.TraceInjectingExecutionInterceptor
 import java.net.URI
 
 class SqsClientFactory {
@@ -23,6 +24,7 @@ class SqsClientFactory {
     return SqsAsyncClient.builder()
       .credentialsProvider(credentialsProvider)
       .region(Region.of(region))
+      .overrideConfiguration { it.addExecutionInterceptor(TraceInjectingExecutionInterceptor()) }
       .build()
   }
 
@@ -31,5 +33,6 @@ class SqsClientFactory {
       .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create("any", "any")))
       .endpointOverride(URI.create(localstackUrl))
       .region(Region.of(region))
+      .overrideConfiguration { it.addExecutionInterceptor(TraceInjectingExecutionInterceptor()) }
       .build()
 }

--- a/hmpps-sqs-spring-boot-autoconfigure/src/main/kotlin/uk/gov/justice/hmpps/sqs/telemetry/TraceExtractingMessageInterceptor.kt
+++ b/hmpps-sqs-spring-boot-autoconfigure/src/main/kotlin/uk/gov/justice/hmpps/sqs/telemetry/TraceExtractingMessageInterceptor.kt
@@ -1,0 +1,70 @@
+package uk.gov.justice.hmpps.sqs.telemetry
+
+import com.fasterxml.jackson.core.type.TypeReference
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.awspring.cloud.sqs.MessageHeaderUtils
+import io.awspring.cloud.sqs.listener.interceptor.MessageInterceptor
+import io.opentelemetry.api.GlobalOpenTelemetry
+import io.opentelemetry.api.trace.Span
+import io.opentelemetry.api.trace.SpanKind
+import io.opentelemetry.context.Context
+import io.opentelemetry.context.Scope
+import io.opentelemetry.context.propagation.TextMapGetter
+import org.springframework.messaging.Message
+
+/**
+ * Intercepts messages before they are passed to the `@SqsListener`.
+ *
+ * On receiving a message, this interceptor will:
+ *  1. attempt to extract the trace context from the message attributes,
+ *  2. start a new OpenTelemetry span with the name "RECEIVE $eventType",
+ *  3. end the span once the message has finished processing.
+ */
+class TraceExtractingMessageInterceptor(private val objectMapper: ObjectMapper) : MessageInterceptor<Any> {
+  override fun intercept(message: Message<Any>): Message<Any> {
+    val payload = message.payload
+    if (payload !is String) return message
+
+    val attributes = objectMapper.readValue(
+      objectMapper.readTree(payload).at("/MessageAttributes").traverse(),
+      object : TypeReference<MutableMap<String, MessageAttribute>>() {},
+    )
+    val spanName = attributes["eventType"]?.let { "RECEIVE ${it.Value}" } ?: "RECEIVE"
+    val span = attributes.extractTelemetryContext().startSpan(spanName)
+
+    return message
+      .withHeader("span", span)
+      .withHeader("scope", span.makeCurrent())
+  }
+
+  override fun afterProcessing(message: Message<Any>, t: Throwable?) {
+    (message.headers["span"] as Span?)?.end()
+    (message.headers["scope"] as Scope?)?.close()
+  }
+
+  override fun intercept(messages: Collection<Message<Any>>) = messages.map { intercept(it) }
+
+  override fun afterProcessing(messages: Collection<Message<Any>>, t: Throwable?) =
+    messages.forEach { afterProcessing(it, t) }
+
+  private fun <T> Message<T>.withHeader(headerName: String, headerValue: Any) =
+    MessageHeaderUtils.addHeaderIfAbsent(this, headerName, headerValue)
+
+  private fun MutableMap<String, MessageAttribute>.extractTelemetryContext(): Context {
+    val getter = object : TextMapGetter<MutableMap<String, MessageAttribute>> {
+      override fun keys(carrier: MutableMap<String, MessageAttribute>) = carrier.keys
+      override fun get(carrier: MutableMap<String, MessageAttribute>?, key: String) =
+        carrier?.get(key)?.Value.toString()
+    }
+    return GlobalOpenTelemetry.getPropagators().textMapPropagator.extract(Context.current(), this, getter)
+  }
+
+  private fun Context.startSpan(spanName: String): Span = GlobalOpenTelemetry
+    .getTracer("hmpps-sqs")
+    .spanBuilder(spanName)
+    .setParent(this)
+    .setSpanKind(SpanKind.CONSUMER)
+    .startSpan()
+
+  private class MessageAttribute(val Type: String, val Value: Any?)
+}

--- a/hmpps-sqs-spring-boot-autoconfigure/src/main/kotlin/uk/gov/justice/hmpps/sqs/telemetry/TraceInjectingExecutionInterceptor.kt
+++ b/hmpps-sqs-spring-boot-autoconfigure/src/main/kotlin/uk/gov/justice/hmpps/sqs/telemetry/TraceInjectingExecutionInterceptor.kt
@@ -1,0 +1,75 @@
+package uk.gov.justice.hmpps.sqs.telemetry
+
+import io.opentelemetry.api.GlobalOpenTelemetry
+import io.opentelemetry.api.trace.Span
+import io.opentelemetry.api.trace.SpanKind
+import io.opentelemetry.instrumentation.annotations.WithSpan
+import software.amazon.awssdk.core.interceptor.Context
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes
+import software.amazon.awssdk.core.interceptor.ExecutionInterceptor
+import software.amazon.awssdk.services.sns.model.PublishBatchRequest
+import software.amazon.awssdk.services.sns.model.PublishRequest
+import software.amazon.awssdk.services.sqs.model.SendMessageBatchRequest
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest
+import io.opentelemetry.context.Context as SpanContext
+import software.amazon.awssdk.services.sns.model.MessageAttributeValue as SnsMessageAttributeValue
+import software.amazon.awssdk.services.sqs.model.MessageAttributeValue as SqsMessageAttributeValue
+
+/**
+ * Intercepts `PublishRequest` and `SendMessageRequest` requests, and
+ *  1. creates an OpenTelemetry span with the name "PUBLISH $eventType",
+ *  2. injects the trace context into the message attributes before sending.
+ */
+class TraceInjectingExecutionInterceptor : ExecutionInterceptor {
+  override fun modifyRequest(context: Context.ModifyRequest?, executionAttributes: ExecutionAttributes?) =
+    when (val request = context?.request()) {
+      is PublishRequest -> publishSpan(request.messageAttributes()["eventType"]?.stringValue()) {
+        request.toBuilder().messageAttributes(request.messageAttributes().withSnsTelemetryContext()).build()
+      }
+
+      is PublishBatchRequest -> publishSpan {
+        request.toBuilder().publishBatchRequestEntries(
+          request.publishBatchRequestEntries().map { entry ->
+            entry.toBuilder().messageAttributes(entry.messageAttributes().withSnsTelemetryContext()).build()
+          },
+        ).build()
+      }
+
+      is SendMessageRequest -> publishSpan(request.messageAttributes()["eventType"]?.stringValue()) {
+        request.toBuilder().messageAttributes(request.messageAttributes().withSqsTelemetryContext()).build()
+      }
+
+      is SendMessageBatchRequest -> publishSpan {
+        request.toBuilder().entries(
+          request.entries().map { entry ->
+            entry.toBuilder().messageAttributes(entry.messageAttributes().withSqsTelemetryContext()).build()
+          },
+        ).build()
+      }
+
+      else -> request
+    }
+
+  /**
+   * Creates a "PUBLISH" span and injects
+   */
+  @WithSpan(kind = SpanKind.PRODUCER)
+  private fun <T> publishSpan(eventType: String? = null, modifiedRequest: () -> T): T {
+    Span.current().updateName(eventType?.let { "PUBLISH $it" } ?: "PUBLISH")
+    return modifiedRequest()
+  }
+
+  private fun MutableMap<String, SnsMessageAttributeValue>.withSnsTelemetryContext() = toMutableMap().also {
+    val context = SpanContext.current().with(Span.current())
+    GlobalOpenTelemetry.getPropagators().textMapPropagator.inject(context, it) { carrier, key, value ->
+      carrier!![key] = SnsMessageAttributeValue.builder().dataType("String").stringValue(value).build()
+    }
+  }
+
+  private fun MutableMap<String, SqsMessageAttributeValue>.withSqsTelemetryContext() = toMutableMap().also {
+    val context = SpanContext.current().with(Span.current())
+    GlobalOpenTelemetry.getPropagators().textMapPropagator.inject(context, it) { carrier, key, value ->
+      carrier!![key] = SqsMessageAttributeValue.builder().dataType("String").stringValue(value).build()
+    }
+  }
+}

--- a/hmpps-sqs-spring-boot-autoconfigure/src/test/kotlin/uk/gov/justice/hmpps/sqs/HmppsQueueFactoryTest.kt
+++ b/hmpps-sqs-spring-boot-autoconfigure/src/test/kotlin/uk/gov/justice/hmpps/sqs/HmppsQueueFactoryTest.kt
@@ -2,6 +2,7 @@
 
 package uk.gov.justice.hmpps.sqs
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
@@ -38,7 +39,8 @@ class HmppsQueueFactoryTest {
   private val healthContributorRegistry = mock<HmppsHealthContributorRegistry>()
   private val beanFactory = mock<ConfigurableListableBeanFactory>()
   private val sqsFactory = mock<SqsClientFactory>()
-  private val hmppsQueueFactory = HmppsQueueFactory(context, healthContributorRegistry, sqsFactory)
+  private val objectMapper = mock<ObjectMapper>()
+  private val hmppsQueueFactory = HmppsQueueFactory(context, healthContributorRegistry, sqsFactory, objectMapper)
 
   init {
     whenever(context.beanFactory).thenReturn(beanFactory)

--- a/hmpps-sqs-spring-boot-autoconfigure/src/test/kotlin/uk/gov/justice/hmpps/sqs/HmppsQueueFactoryTest_NoDlq.kt
+++ b/hmpps-sqs-spring-boot-autoconfigure/src/test/kotlin/uk/gov/justice/hmpps/sqs/HmppsQueueFactoryTest_NoDlq.kt
@@ -2,6 +2,7 @@
 
 package uk.gov.justice.hmpps.sqs
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
@@ -42,7 +43,8 @@ class HmppsQueueFactoryTest_NoDlq {
   private val healthContributorRegistry = mock<HmppsHealthContributorRegistry>()
   private val beanFactory = mock<ConfigurableListableBeanFactory>()
   private val sqsFactory = mock<SqsClientFactory>()
-  private val hmppsQueueFactory = HmppsQueueFactory(context, healthContributorRegistry, sqsFactory)
+  private val objectMapper = mock<ObjectMapper>()
+  private val hmppsQueueFactory = HmppsQueueFactory(context, healthContributorRegistry, sqsFactory, objectMapper)
 
   init {
     whenever(context.beanFactory).thenReturn(beanFactory)

--- a/release-notes/4.x.md
+++ b/release-notes/4.x.md
@@ -1,3 +1,10 @@
+# 4.1.0
+
+This release enables distributed tracing across message publishers and receivers by adding OpenTelemetry trace headers
+to SQS message attributes. Message attributes with the names "traceparent" and/or "tracestate" will be added to your 
+messages on publishing, and you will see a single end-to-end transaction linking your message publishers and receivers
+in Azure Application Insights.
+
 # 4.0.1
 This release upgrades to Spring Boot 3.3.1
 

--- a/test-app-reactive/build.gradle.kts
+++ b/test-app-reactive/build.gradle.kts
@@ -35,7 +35,8 @@ dependencies {
   testImplementation("com.amazonaws:aws-java-sdk-core:1.12.748") // needed so that Localstack has access to the AWS SDK V1 API
   testImplementation("com.google.code.gson:gson:2.11.0")
   testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test")
-  testImplementation("io.opentelemetry:opentelemetry-extension-trace-propagators:1.40.0")
+  testImplementation("io.opentelemetry:opentelemetry-extension-trace-propagators")
+  testImplementation("io.opentelemetry:opentelemetry-sdk-testing")
 }
 
 kotlin {

--- a/test-app-reactive/build.gradle.kts
+++ b/test-app-reactive/build.gradle.kts
@@ -16,6 +16,7 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server")
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor")
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-jdk8")
+  implementation("io.opentelemetry:opentelemetry-extension-kotlin:1.40.0")
 
   implementation("org.springdoc:springdoc-openapi-starter-webflux-ui:2.5.0")
 
@@ -34,6 +35,7 @@ dependencies {
   testImplementation("com.amazonaws:aws-java-sdk-core:1.12.748") // needed so that Localstack has access to the AWS SDK V1 API
   testImplementation("com.google.code.gson:gson:2.11.0")
   testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test")
+  testImplementation("io.opentelemetry:opentelemetry-extension-trace-propagators:1.40.0")
 }
 
 kotlin {

--- a/test-app-reactive/build.gradle.kts
+++ b/test-app-reactive/build.gradle.kts
@@ -16,7 +16,7 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server")
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor")
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-jdk8")
-  implementation("io.opentelemetry:opentelemetry-extension-kotlin:1.40.0")
+  implementation("io.opentelemetry:opentelemetry-extension-kotlin")
 
   implementation("org.springdoc:springdoc-openapi-starter-webflux-ui:2.5.0")
 

--- a/test-app-reactive/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppstemplatepackagenameasync/integration/TelemetryPropagationTest.kt
+++ b/test-app-reactive/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppstemplatepackagenameasync/integration/TelemetryPropagationTest.kt
@@ -1,0 +1,54 @@
+package uk.gov.justice.digital.hmpps.hmppstemplatepackagenameasync.integration
+
+import io.opentelemetry.api.GlobalOpenTelemetry
+import io.opentelemetry.api.OpenTelemetry
+import io.opentelemetry.api.trace.Span
+import io.opentelemetry.api.trace.SpanContext
+import io.opentelemetry.api.trace.TraceFlags
+import io.opentelemetry.api.trace.TraceState
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator
+import io.opentelemetry.context.Context
+import io.opentelemetry.context.propagation.ContextPropagators
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.awaitility.kotlin.await
+import org.awaitility.kotlin.matches
+import org.awaitility.kotlin.untilCallTo
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import software.amazon.awssdk.services.sns.model.MessageAttributeValue
+import software.amazon.awssdk.services.sns.model.PublishRequest
+import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest
+import uk.gov.justice.digital.hmpps.hmppstemplatepackagenameasync.service.HmppsEvent
+import uk.gov.justice.digital.hmpps.hmppstemplatepackagenameasync.service.Message
+import uk.gov.justice.hmpps.sqs.countMessagesOnQueue
+
+class TelemetryPropagationTest : IntegrationTestBase() {
+  @BeforeEach
+  fun setup() {
+    GlobalOpenTelemetry.resetForTest()
+    GlobalOpenTelemetry.set(OpenTelemetry.propagating(ContextPropagators.create(W3CTraceContextPropagator.getInstance())))
+  }
+
+  @Test
+  fun `telemetry information is propagated between publishers and listeners`() = runTest {
+    // Given a trace id
+    Span.wrap(SpanContext.create("1234567890abcdef1234567890abcdef", "1234567890abcdef", TraceFlags.getDefault(), TraceState.getDefault()))
+      .also { Context.current().with(it).makeCurrent() }
+
+    // When I publish an OFFENDER_MOVEMENT-RECEPTION message
+    val event = HmppsEvent("event-id", "OFFENDER_MOVEMENT-RECEPTION", "some event contents")
+    inboundSnsClient.publish(
+      PublishRequest.builder().topicArn(inboundTopicArn).message(gsonString(event)).messageAttributes(
+        mapOf("eventType" to MessageAttributeValue.builder().dataType("String").stringValue(event.type).build()),
+      ).build(),
+    )
+
+    // And the OFFENDER_MOVEMENT-RECEPTION message is consumed, resulting in an offender.movement.reception message being published
+    await untilCallTo { outboundTestSqsClient.countMessagesOnQueue(outboundTestQueueUrl).get() } matches { it == 1 }
+
+    // Then the trace headers have been passed all the way through
+    val message = objectMapper.readValue(outboundTestSqsClient.receiveMessage(ReceiveMessageRequest.builder().queueUrl(outboundTestQueueUrl).build()).get().messages()[0].body(), Message::class.java)
+    assertThat(message.MessageAttributes["traceparent"]?.Value).isEqualTo("00-1234567890abcdef1234567890abcdef-1234567890abcdef-00")
+  }
+}

--- a/test-app-reactive/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppstemplatepackagenameasync/integration/TelemetryPropagationTest.kt
+++ b/test-app-reactive/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppstemplatepackagenameasync/integration/TelemetryPropagationTest.kt
@@ -1,21 +1,15 @@
 package uk.gov.justice.digital.hmpps.hmppstemplatepackagenameasync.integration
 
-import io.opentelemetry.api.GlobalOpenTelemetry
-import io.opentelemetry.api.OpenTelemetry
 import io.opentelemetry.api.trace.Span
-import io.opentelemetry.api.trace.SpanContext
-import io.opentelemetry.api.trace.TraceFlags
-import io.opentelemetry.api.trace.TraceState
-import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator
 import io.opentelemetry.context.Context
-import io.opentelemetry.context.propagation.ContextPropagators
+import io.opentelemetry.sdk.testing.junit5.OpenTelemetryExtension
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.awaitility.kotlin.await
 import org.awaitility.kotlin.matches
 import org.awaitility.kotlin.untilCallTo
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 import software.amazon.awssdk.services.sns.model.MessageAttributeValue
 import software.amazon.awssdk.services.sns.model.PublishRequest
 import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest
@@ -24,31 +18,47 @@ import uk.gov.justice.digital.hmpps.hmppstemplatepackagenameasync.service.Messag
 import uk.gov.justice.hmpps.sqs.countMessagesOnQueue
 
 class TelemetryPropagationTest : IntegrationTestBase() {
-  @BeforeEach
-  fun setup() {
-    GlobalOpenTelemetry.resetForTest()
-    GlobalOpenTelemetry.set(OpenTelemetry.propagating(ContextPropagators.create(W3CTraceContextPropagator.getInstance())))
+  companion object {
+    @RegisterExtension
+    val openTelemetryExtension: OpenTelemetryExtension = OpenTelemetryExtension.create()
   }
 
   @Test
   fun `telemetry information is propagated between publishers and listeners`() = runTest {
-    // Given a trace id
-    Span.wrap(SpanContext.create("1234567890abcdef1234567890abcdef", "1234567890abcdef", TraceFlags.getDefault(), TraceState.getDefault()))
-      .also { Context.current().with(it).makeCurrent() }
-
-    // When I publish an OFFENDER_MOVEMENT-RECEPTION message
-    val event = HmppsEvent("event-id", "OFFENDER_MOVEMENT-RECEPTION", "some event contents")
-    inboundSnsClient.publish(
-      PublishRequest.builder().topicArn(inboundTopicArn).message(gsonString(event)).messageAttributes(
-        mapOf("eventType" to MessageAttributeValue.builder().dataType("String").stringValue(event.type).build()),
-      ).build(),
-    )
+    // Given a span
+    val span = withSpan {
+      // When I publish an OFFENDER_MOVEMENT-RECEPTION message
+      val event = HmppsEvent("event-id", "OFFENDER_MOVEMENT-RECEPTION", "some event contents")
+      inboundSnsClient.publish(
+        PublishRequest.builder()
+          .topicArn(inboundTopicArn)
+          .message(gsonString(event))
+          .messageAttributes(mapOf("eventType" to MessageAttributeValue.builder().dataType("String").stringValue(event.type).build()))
+          .build(),
+      )
+    }
 
     // And the OFFENDER_MOVEMENT-RECEPTION message is consumed, resulting in an offender.movement.reception message being published
     await untilCallTo { outboundTestSqsClient.countMessagesOnQueue(outboundTestQueueUrl).get() } matches { it == 1 }
 
     // Then the trace headers have been passed all the way through
     val message = objectMapper.readValue(outboundTestSqsClient.receiveMessage(ReceiveMessageRequest.builder().queueUrl(outboundTestQueueUrl).build()).get().messages()[0].body(), Message::class.java)
-    assertThat(message.MessageAttributes["traceparent"]?.Value).isEqualTo("00-1234567890abcdef1234567890abcdef-1234567890abcdef-00")
+    assertThat(message.MessageAttributes["traceparent"]?.Value).matches("00-${span.spanContext.traceId}-[0-9a-f]{16}-01")
+
+    // And PUBLISH and RECEIVE spans are exported
+    assertThat(openTelemetryExtension.spans.map { it.name }).containsAll(
+      setOf(
+        "PUBLISH OFFENDER_MOVEMENT-RECEPTION",
+        "RECEIVE OFFENDER_MOVEMENT-RECEPTION",
+        "PUBLISH offender.movement.reception",
+        "RECEIVE offender.movement.reception",
+      ),
+    )
+  }
+
+  private fun withSpan(block: () -> Unit): Span {
+    val span = openTelemetryExtension.openTelemetry.getTracer("hmpps-sqs").spanBuilder("test-span").startSpan()
+    Context.current().with(span).makeCurrent().use { block() }
+    return span.also { it.end() }
   }
 }

--- a/test-app/build.gradle.kts
+++ b/test-app/build.gradle.kts
@@ -14,7 +14,7 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server")
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor")
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-jdk8")
-  implementation("io.opentelemetry:opentelemetry-extension-kotlin:1.40.0")
+  implementation("io.opentelemetry:opentelemetry-extension-kotlin")
 
   implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0")
 

--- a/test-app/build.gradle.kts
+++ b/test-app/build.gradle.kts
@@ -33,7 +33,8 @@ dependencies {
   testImplementation("com.amazonaws:aws-java-sdk-core:1.12.748") // Needed so Localstack has access to the AWS SDK V1 API
   testImplementation("com.google.code.gson:gson:2.11.0")
   testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test")
-  testImplementation("io.opentelemetry:opentelemetry-extension-trace-propagators:1.40.0")
+  testImplementation("io.opentelemetry:opentelemetry-extension-trace-propagators")
+  testImplementation("io.opentelemetry:opentelemetry-sdk-testing")
 }
 
 kotlin {

--- a/test-app/build.gradle.kts
+++ b/test-app/build.gradle.kts
@@ -14,6 +14,7 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server")
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor")
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-jdk8")
+  implementation("io.opentelemetry:opentelemetry-extension-kotlin:1.40.0")
 
   implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0")
 
@@ -32,6 +33,7 @@ dependencies {
   testImplementation("com.amazonaws:aws-java-sdk-core:1.12.748") // Needed so Localstack has access to the AWS SDK V1 API
   testImplementation("com.google.code.gson:gson:2.11.0")
   testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test")
+  testImplementation("io.opentelemetry:opentelemetry-extension-trace-propagators:1.40.0")
 }
 
 kotlin {

--- a/test-app/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppstemplatepackagename/service/MessageListener.kt
+++ b/test-app/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppstemplatepackagename/service/MessageListener.kt
@@ -2,8 +2,9 @@ package uk.gov.justice.digital.hmpps.hmppstemplatepackagename.service
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.awspring.cloud.sqs.annotation.SqsListener
+import io.opentelemetry.context.Context
+import io.opentelemetry.extension.kotlin.asContextElement
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.future.future
 import org.springframework.stereotype.Service
 import java.util.concurrent.CompletableFuture
@@ -14,7 +15,7 @@ class InboundMessageListener(private val inboundMessageService: InboundMessageSe
   @SqsListener("inboundqueue", factory = "hmppsQueueContainerFactoryProxy")
   fun processMessage(message: Message): CompletableFuture<Void> {
     val event = objectMapper.readValue(message.Message, HmppsEvent::class.java)
-    return CoroutineScope(Dispatchers.Default).future {
+    return CoroutineScope(Context.current().asContextElement()).future {
       inboundMessageService.handleMessage(event)
     }.thenAccept {}
   }
@@ -31,8 +32,13 @@ class OutboundMessageListener(private val outboundMessageService: OutboundMessag
 }
 
 data class HmppsEvent(val id: String, val type: String, val contents: String)
-data class EventType(val Value: String, val Type: String)
-data class MessageAttributes(val eventType: EventType)
+data class MessageAttribute(val Value: String, val Type: String)
+typealias EventType = MessageAttribute
+class MessageAttributes() : HashMap<String, MessageAttribute>() {
+  constructor(attribute: EventType) : this() {
+    put(attribute.Value, attribute)
+  }
+}
 data class Message(
   val Message: String,
   val MessageId: String,

--- a/test-app/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppstemplatepackagename/integration/TelemetryPropagationTest.kt
+++ b/test-app/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppstemplatepackagename/integration/TelemetryPropagationTest.kt
@@ -1,0 +1,54 @@
+package uk.gov.justice.digital.hmpps.hmppstemplatepackagename.integration
+
+import io.opentelemetry.api.GlobalOpenTelemetry
+import io.opentelemetry.api.OpenTelemetry
+import io.opentelemetry.api.trace.Span
+import io.opentelemetry.api.trace.SpanContext
+import io.opentelemetry.api.trace.TraceFlags
+import io.opentelemetry.api.trace.TraceState
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator
+import io.opentelemetry.context.Context
+import io.opentelemetry.context.propagation.ContextPropagators
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.awaitility.kotlin.await
+import org.awaitility.kotlin.matches
+import org.awaitility.kotlin.untilCallTo
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import software.amazon.awssdk.services.sns.model.MessageAttributeValue
+import software.amazon.awssdk.services.sns.model.PublishRequest
+import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest
+import uk.gov.justice.digital.hmpps.hmppstemplatepackagename.service.HmppsEvent
+import uk.gov.justice.digital.hmpps.hmppstemplatepackagename.service.Message
+import uk.gov.justice.hmpps.sqs.countMessagesOnQueue
+
+class TelemetryPropagationTest : IntegrationTestBase() {
+  @BeforeEach
+  fun setup() {
+    GlobalOpenTelemetry.resetForTest()
+    GlobalOpenTelemetry.set(OpenTelemetry.propagating(ContextPropagators.create(W3CTraceContextPropagator.getInstance())))
+  }
+
+  @Test
+  fun `telemetry information is propagated between publishers and listeners`() = runTest {
+    // Given a trace id
+    Span.wrap(SpanContext.create("1234567890abcdef1234567890abcdef", "1234567890abcdef", TraceFlags.getDefault(), TraceState.getDefault()))
+      .also { Context.current().with(it).makeCurrent() }
+
+    // When I publish an OFFENDER_MOVEMENT-RECEPTION message
+    val event = HmppsEvent("event-id", "OFFENDER_MOVEMENT-RECEPTION", "some event contents")
+    inboundSnsClient.publish(
+      PublishRequest.builder().topicArn(inboundTopicArn).message(gsonString(event)).messageAttributes(
+        mapOf("eventType" to MessageAttributeValue.builder().dataType("String").stringValue(event.type).build()),
+      ).build(),
+    )
+
+    // And the OFFENDER_MOVEMENT-RECEPTION message is consumed, resulting in an offender.movement.reception message being published
+    await untilCallTo { outboundTestSqsClient.countMessagesOnQueue(outboundTestQueueUrl).get() } matches { it == 1 }
+
+    // Then the trace headers have been passed all the way through
+    val message = objectMapper.readValue(outboundTestSqsClient.receiveMessage(ReceiveMessageRequest.builder().queueUrl(outboundTestQueueUrl).build()).get().messages()[0].body(), Message::class.java)
+    assertThat(message.MessageAttributes["traceparent"]?.Value).isEqualTo("00-1234567890abcdef1234567890abcdef-1234567890abcdef-00")
+  }
+}

--- a/test-app/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppstemplatepackagename/integration/TelemetryPropagationTest.kt
+++ b/test-app/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppstemplatepackagename/integration/TelemetryPropagationTest.kt
@@ -1,21 +1,15 @@
 package uk.gov.justice.digital.hmpps.hmppstemplatepackagename.integration
 
-import io.opentelemetry.api.GlobalOpenTelemetry
-import io.opentelemetry.api.OpenTelemetry
 import io.opentelemetry.api.trace.Span
-import io.opentelemetry.api.trace.SpanContext
-import io.opentelemetry.api.trace.TraceFlags
-import io.opentelemetry.api.trace.TraceState
-import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator
 import io.opentelemetry.context.Context
-import io.opentelemetry.context.propagation.ContextPropagators
+import io.opentelemetry.sdk.testing.junit5.OpenTelemetryExtension
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.awaitility.kotlin.await
 import org.awaitility.kotlin.matches
 import org.awaitility.kotlin.untilCallTo
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 import software.amazon.awssdk.services.sns.model.MessageAttributeValue
 import software.amazon.awssdk.services.sns.model.PublishRequest
 import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest
@@ -24,31 +18,47 @@ import uk.gov.justice.digital.hmpps.hmppstemplatepackagename.service.Message
 import uk.gov.justice.hmpps.sqs.countMessagesOnQueue
 
 class TelemetryPropagationTest : IntegrationTestBase() {
-  @BeforeEach
-  fun setup() {
-    GlobalOpenTelemetry.resetForTest()
-    GlobalOpenTelemetry.set(OpenTelemetry.propagating(ContextPropagators.create(W3CTraceContextPropagator.getInstance())))
+  companion object {
+    @RegisterExtension
+    val openTelemetryExtension: OpenTelemetryExtension = OpenTelemetryExtension.create()
   }
 
   @Test
   fun `telemetry information is propagated between publishers and listeners`() = runTest {
-    // Given a trace id
-    Span.wrap(SpanContext.create("1234567890abcdef1234567890abcdef", "1234567890abcdef", TraceFlags.getDefault(), TraceState.getDefault()))
-      .also { Context.current().with(it).makeCurrent() }
-
-    // When I publish an OFFENDER_MOVEMENT-RECEPTION message
-    val event = HmppsEvent("event-id", "OFFENDER_MOVEMENT-RECEPTION", "some event contents")
-    inboundSnsClient.publish(
-      PublishRequest.builder().topicArn(inboundTopicArn).message(gsonString(event)).messageAttributes(
-        mapOf("eventType" to MessageAttributeValue.builder().dataType("String").stringValue(event.type).build()),
-      ).build(),
-    )
+    // Given a span
+    val span = withSpan {
+      // When I publish an OFFENDER_MOVEMENT-RECEPTION message
+      val event = HmppsEvent("event-id", "OFFENDER_MOVEMENT-RECEPTION", "some event contents")
+      inboundSnsClient.publish(
+        PublishRequest.builder()
+          .topicArn(inboundTopicArn)
+          .message(gsonString(event))
+          .messageAttributes(mapOf("eventType" to MessageAttributeValue.builder().dataType("String").stringValue(event.type).build()))
+          .build(),
+      )
+    }
 
     // And the OFFENDER_MOVEMENT-RECEPTION message is consumed, resulting in an offender.movement.reception message being published
     await untilCallTo { outboundTestSqsClient.countMessagesOnQueue(outboundTestQueueUrl).get() } matches { it == 1 }
 
     // Then the trace headers have been passed all the way through
     val message = objectMapper.readValue(outboundTestSqsClient.receiveMessage(ReceiveMessageRequest.builder().queueUrl(outboundTestQueueUrl).build()).get().messages()[0].body(), Message::class.java)
-    assertThat(message.MessageAttributes["traceparent"]?.Value).isEqualTo("00-1234567890abcdef1234567890abcdef-1234567890abcdef-00")
+    assertThat(message.MessageAttributes["traceparent"]?.Value).matches("00-${span.spanContext.traceId}-[0-9a-f]{16}-01")
+
+    // And PUBLISH and RECEIVE spans are exported
+    assertThat(openTelemetryExtension.spans.map { it.name }).containsAll(
+      setOf(
+        "PUBLISH OFFENDER_MOVEMENT-RECEPTION",
+        "RECEIVE OFFENDER_MOVEMENT-RECEPTION",
+        "PUBLISH offender.movement.reception",
+        "RECEIVE offender.movement.reception",
+      ),
+    )
+  }
+
+  private fun withSpan(block: () -> Unit): Span {
+    val span = openTelemetryExtension.openTelemetry.getTracer("hmpps-sqs").spanBuilder("test-span").startSpan()
+    Context.current().with(span).makeCurrent().use { block() }
+    return span.also { it.end() }
   }
 }


### PR DESCRIPTION
This PR adds the OpenTelemetry trace context into the MessageAttributes before publishing to a topic or sending to a queue. It also adds an interceptor to extract the trace context, if present, and configure the current span on receiving a message.

The result is a single joined-up transaction in Application Insights, allowing you to trace message processing back to the message source. It also enables a richer dependency graph, as we can now track which services interact with each other over the SNS/SQS message boundary.

### Example
The following app insights transaction shows a message being published by `prison-identifier-and-delius`, which is then received by the `prison-custody-status-to-delius` and `custody-key-dates-and-delius` services:

![image](https://github.com/user-attachments/assets/6166f015-1298-4078-8a66-e47b3bb4e5e7)

Also, the developer portal now shows that the `prison-identifier-and-delius` service is being relied upon by the two consuming services: https://developer-portal.hmpps.service.justice.gov.uk/components/prison-identifier-and-delius

![image](https://github.com/user-attachments/assets/7d596d01-f23f-44e5-957a-dfb09b237f94)

