### PR TITLE
PIC-4364 Add messageGroupId parameter to HmppsTopic.publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ FIFO Queues can only subscribe to FIFO Topics.
 FIFO allows you the option to configure message deduplication and guarantees ordering. There are performance tradeoffs.
 [More information on FIFO here](https://docs.aws.amazon.com/sns/latest/dg/sns-fifo-topics.html)
 
+To publish a message to a FIFO topic you must include a `MessageGroupId`.
+
 #### HmppsSqsProperties Definitions
 
 ##### :warning: queueId and topicId Must Be All Lowercase And Alpha

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 
 allprojects {
   group = "uk.gov.justice.service.hmpps"
-  version = "5.2.0"
+  version = "5.2.1"
   repositories {
     mavenCentral()
   }

--- a/release-notes/5.x.md
+++ b/release-notes/5.x.md
@@ -1,3 +1,8 @@
+# 5.2.1
+
+We now allow the parameter messageGroupId in HmppsTopic.publish method. This is required when you want to publish a message on
+a FIFO topic.
+
 # 5.2.0
 
 Updating dependencies:

--- a/test-app-reactive/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppstemplatepackagenameasync/integration/IntegrationTestBase.kt
+++ b/test-app-reactive/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppstemplatepackagenameasync/integration/IntegrationTestBase.kt
@@ -71,7 +71,7 @@ abstract class IntegrationTestBase {
   private val outboundQueue by lazy { hmppsQueueService.findByQueueId("outboundqueue") ?: throw MissingQueueException("HmppsQueue outboundqueue not found") }
   private val outboundTestQueue by lazy { hmppsQueueService.findByQueueId("outboundtestqueue") ?: throw MissingQueueException("HmppsQueue outboundtestqueue not found") }
   private val inboundTopic by lazy { hmppsQueueService.findByTopicId("inboundtopic") ?: throw MissingQueueException("HmppsTopic inboundtopic not found") }
-  private val fifoTopic by lazy { hmppsQueueService.findByTopicId("fifotopic") ?: throw MissingQueueException("HmppsTopic fifotopic not found") }
+  internal val fifoTopic by lazy { hmppsQueueService.findByTopicId("fifotopic") ?: throw MissingQueueException("HmppsTopic fifotopic not found") }
   private val outboundTestNoDlqQueue by lazy { hmppsQueueService.findByQueueId("outboundtestnodlqqueue") ?: throw MissingQueueException("HmppsQueue outboundtestnodlqqueue not found") }
   private val auditQueue by lazy { hmppsQueueService.findByQueueId("audit") ?: throw MissingQueueException("HmppsQueue audit not found") }
   private val fifoQueue by lazy { hmppsQueueService.findByQueueId("fifoqueue") ?: throw MissingQueueException("HmppsQueue fifoqueue not found") }
@@ -82,7 +82,6 @@ abstract class IntegrationTestBase {
   protected val inboundSqsClient by lazy { inboundQueue.sqsClient }
   protected val inboundSqsDlqClient by lazy { inboundQueue.sqsDlqClient as SqsAsyncClient }
   protected val inboundSnsClient by lazy { inboundTopic.snsClient }
-  protected val fifoSnsClient by lazy { fifoTopic.snsClient }
   protected val outboundTestSqsClient by lazy { outboundTestQueue.sqsClient }
   protected val outboundTestNoDlqSqsClient by lazy { outboundTestNoDlqQueue.sqsClient }
   protected val auditSqsClient by lazy { auditQueue.sqsClient }
@@ -112,7 +111,6 @@ abstract class IntegrationTestBase {
   protected val outboundSqsOnlyTestQueueUrl by lazy { outboundSqsOnlyTestQueue.queueUrl }
 
   protected val inboundTopicArn by lazy { inboundTopic.arn }
-  protected val fifoTopicArn by lazy { fifoTopic.arn }
 
   @Autowired
   protected lateinit var objectMapper: ObjectMapper

--- a/test-app/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppstemplatepackagename/integration/IntegrationTestBase.kt
+++ b/test-app/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppstemplatepackagename/integration/IntegrationTestBase.kt
@@ -72,7 +72,7 @@ abstract class IntegrationTestBase {
   private val outboundTestQueue by lazy { hmppsQueueService.findByQueueId("outboundtestqueue") ?: throw MissingQueueException("HmppsQueue outboundtestqueue not found") }
   private val inboundTopic by lazy { hmppsQueueService.findByTopicId("inboundtopic") ?: throw MissingQueueException("HmppsTopic inboundtopic not found") }
   protected val outboundTopic by lazy { hmppsQueueService.findByTopicId("outboundtopic") ?: throw MissingQueueException("HmppsTopic outboundtopic not found") }
-  private val fifoTopic by lazy { hmppsQueueService.findByTopicId("fifotopic") ?: throw MissingQueueException("HmppsTopic fifotopic not found") }
+  internal val fifoTopic by lazy { hmppsQueueService.findByTopicId("fifotopic") ?: throw MissingQueueException("HmppsTopic fifotopic not found") }
   private val outboundTestNoDlqQueue by lazy { hmppsQueueService.findByQueueId("outboundtestnodlqqueue") ?: throw MissingQueueException("HmppsQueue outboundtestnodlqqueue not found") }
   private val auditQueue by lazy { hmppsQueueService.findByQueueId("audit") ?: throw MissingQueueException("HmppsQueue audit not found") }
   private val fifoQueue by lazy { hmppsQueueService.findByQueueId("fifoqueue") ?: throw MissingQueueException("HmppsQueue fifoqueue not found") }
@@ -83,7 +83,6 @@ abstract class IntegrationTestBase {
   protected val inboundSqsClient by lazy { inboundQueue.sqsClient }
   protected val inboundSqsDlqClient by lazy { inboundQueue.sqsDlqClient as SqsAsyncClient }
   protected val inboundSnsClient by lazy { inboundTopic.snsClient }
-  protected val fifoSnsClient by lazy { fifoTopic.snsClient }
   protected val outboundTestSqsClient by lazy { outboundTestQueue.sqsClient }
   protected val outboundTestNoDlqSqsClient by lazy { outboundTestNoDlqQueue.sqsClient }
   protected val auditSqsClient by lazy { auditQueue.sqsClient }


### PR DESCRIPTION
Allow providing the messageGroupId into a PublishRequest when sending messages to an SNS topic.

This is a required field when publishing a message to a FIFO topic

All existing topic publish calls are unaffected.